### PR TITLE
Fix C4100 warnings in db.cpp: suppress unused parameter warnings

### DIFF
--- a/src/core/src/db.cpp
+++ b/src/core/src/db.cpp
@@ -59,6 +59,7 @@ bool Database::open(const std::string& db_path, const std::string& password) {
     }
 return true;
 #else
+    (void)password;  // Suppress unused parameter warning in fallback mode
     // Fallback: use file-based storage
     db_path_ = db_path;
     is_connected_ = true;
@@ -110,6 +111,7 @@ bool Database::execute(const std::string& sql) {
     }
     std::ofstream log(db_path_ + ".log", std::ios::app);
     log << sql << std::endl;
+    (void)sql;  // Parameter used in log, but mark as intentionally unused for warning suppression
     return true;
 #endif
 }
@@ -158,6 +160,7 @@ Database::QueryResult Database::query(const std::string& sql) {
 
     result.success = true;
 #else
+    (void)sql;  // Suppress unused parameter warning in fallback mode
     // Fallback: return empty result
     if (!is_connected_) {
         last_error_ = "Database not connected";
@@ -221,6 +224,7 @@ bool Database::table_exists(const std::string& table_name) {
     sqlite3_finalize(stmt);
     return exists;
 #else
+    (void)table_name;  // Suppress unused parameter warning in fallback mode
     return true; // Assume exists in fallback mode
 #endif
     }
@@ -285,6 +289,8 @@ bool Database::insert(const std::string& table_name,
     
     return true;
 #else
+    (void)table_name;  // Suppress unused parameter warning in fallback mode
+    (void)data;        // Suppress unused parameter warning in fallback mode
     // Fallback: log to file
     if (!is_connected_) {
         last_error_ = "Database not connected";
@@ -354,6 +360,10 @@ bool Database::update(const std::string& table_name,
     
     return true;
 #else
+    (void)table_name;    // Suppress unused parameter warning in fallback mode
+    (void)data;          // Suppress unused parameter warning in fallback mode
+    (void)where_column;  // Suppress unused parameter warning in fallback mode
+    (void)where_value;   // Suppress unused parameter warning in fallback mode
     if (!is_connected_) {
         last_error_ = "Database not connected";
         return false;
@@ -407,6 +417,9 @@ bool Database::remove(const std::string& table_name,
     
     return true;
 #else
+    (void)table_name;    // Suppress unused parameter warning in fallback mode
+    (void)where_column;  // Suppress unused parameter warning in fallback mode
+    (void)where_value;   // Suppress unused parameter warning in fallback mode
     if (!is_connected_) {
         last_error_ = "Database not connected";
         return false;


### PR DESCRIPTION
## Summary
This PR fixes all C4100 warnings (unreferenced parameter) in `src/core/src/db.cpp` by explicitly marking unused parameters with `(void)parameter` casts.

## Changes

### Fixed Warnings
Added `(void)parameter` suppression for unused parameters in fallback mode (when `HAVE_SQLITE` is not defined):

**Line 34**: `open()` 
- `password` parameter unused in fallback implementation

**Line 117**: `query()`
- `sql` parameter logged but marked as intentionally unused

**Line 201**: `table_exists()`
- `table_name` parameter used only in `#ifdef HAVE_SQLITE` block

**Lines 230-231**: `insert()`
- `table_name` and `data` parameters unused in fallback mode

**Lines 297-300**: `update()`
- `table_name`, `data`, `where_column`, `where_value` all unused in fallback

**Lines 366-368**: `remove()`
- `table_name`, `where_column`, `where_value` all unused in fallback

## Rationale

### Why Keep These Parameters?
These parameters are part of the **public API** and must remain for:
- **API consistency**: Same function signature regardless of build configuration
- **Binary compatibility**: Prevents ABI breaks
- **Future implementation**: Fallback mode may use these in future

### Why Use `(void)parameter`?
- **Standard C++ idiom** for intentionally unused parameters
- **Clear intent**: Explicitly documents that parameter is unused
- **No code generation**: Optimizer removes it entirely
- **MSVC-friendly**: Cleanly suppresses C4100 without pragmas

## Alternatives Considered

❌ **Remove parameters**: Breaks API compatibility
❌ **`[[maybe_unused]]` attribute**: Not supported in C++14
❌ **`#pragma warning(disable:4100)`**: Too broad, suppresses in entire file
✅ **`(void)parameter`**: Clean, standard, targeted solution

## Testing
- ✅ Compiles without C4100 warnings in db.cpp
- ✅ API signature unchanged
- ✅ No functional changes to code logic
- ✅ Fallback and SQLite paths remain identical

## Impact
- **Zero runtime impact**: Optimizer removes `(void)` casts
- **Cleaner builds**: Reduces warning noise in CI/CD
- **Better code quality**: Explicitly documents intent
