### PR TITLE
fix: Resolve MSVC compiler warnings in i2p.cpp

### DIFF
--- a/src/core/src/i2p.cpp
+++ b/src/core/src/i2p.cpp
@@ -34,7 +34,8 @@ struct I2PManager::Impl {
         if (sam_socket < 0) return false;
         
         std::string full_cmd = cmd + "\n";
-        ssize_t sent = send(sam_socket, full_cmd.c_str(), full_cmd.length(), 0);
+        // FIX C4267: Explicit cast to avoid size_t to int conversion warning
+        ssize_t sent = send(sam_socket, full_cmd.c_str(), static_cast<int>(full_cmd.length()), 0);
         if (sent <= 0) return false;
         
         char buffer[4096];
@@ -133,6 +134,9 @@ std::string I2PManager::get_destination() const {
 // HIGH PRIORITY: Create tunnel via SAM
 bool I2PManager::create_tunnel(const std::string& name, uint16_t local_port,
                                const std::string& remote_dest, TunnelType type) {
+    // FIX C4100: Mark unreferenced parameter
+    (void)local_port;
+    
     if (!is_active()) return false;
     
     std::string style = (type == TunnelType::CLIENT) ? "STREAM" : "STREAM";
@@ -298,6 +302,9 @@ std::string I2PManager::export_destination() const {
 
 std::vector<uint8_t> I2PManager::create_garlic_message(
     const std::vector<GarlicClove>& cloves, const std::string& dest_public_key) {
+    // FIX C4100: Mark unreferenced parameter
+    (void)dest_public_key;
+    
     // TODO: Implement garlic encryption using libsodium
     std::vector<uint8_t> result;
     for (const auto& clove : cloves) {
@@ -308,12 +315,20 @@ std::vector<uint8_t> I2PManager::create_garlic_message(
 
 bool I2PManager::send_garlic_message(const std::string& destination,
                                      const std::vector<uint8_t>& message) {
+    // FIX C4100: Mark unreferenced parameters
+    (void)destination;
+    (void)message;
+    
     if (!impl_->sam_connected) return false;
     // TODO: Send via SAM STREAM
     return true;
 }
 
 bool I2PManager::publish_leaseset(bool encrypted, bool blinded) {
+    // FIX C4100: Mark unreferenced parameters
+    (void)encrypted;
+    (void)blinded;
+    
     // TODO: Implement leaseset publishing
     return true;
 }


### PR DESCRIPTION
## 🐛 Bug Fix

This PR resolves all MSVC compiler warnings in `i2p.cpp` that were appearing during Windows builds.

## ⚠️ Warnings Fixed

### 1. C4267: size_t to int conversion (line 37)

**Before:**
```cpp
ssize_t sent = send(sam_socket, full_cmd.c_str(), full_cmd.length(), 0);
```

**After:**
```cpp
ssize_t sent = send(sam_socket, full_cmd.c_str(), static_cast<int>(full_cmd.length()), 0);
```

**Reason**: `send()` expects `int` for buffer length on Windows, but `std::string::length()` returns `size_t`. Explicit cast makes intention clear and removes warning.

---

### 2. C4100: Unreferenced parameters

Added `(void)parameter_name;` to suppress warnings for parameters that will be used in future implementations:

#### Line 134: `local_port` in `create_tunnel()`
```cpp
bool I2PManager::create_tunnel(const std::string& name, uint16_t local_port,
                               const std::string& remote_dest, TunnelType type) {
    (void)local_port;  // Will be used in full SAM implementation
    // ...
}
```

#### Line 300: `dest_public_key` in `create_garlic_message()`
```cpp
std::vector<uint8_t> I2PManager::create_garlic_message(
    const std::vector<GarlicClove>& cloves, const std::string& dest_public_key) {
    (void)dest_public_key;  // TODO: Implement garlic encryption
    // ...
}
```

#### Lines 309-310: `destination` and `message` in `send_garlic_message()`
```cpp
bool I2PManager::send_garlic_message(const std::string& destination,
                                     const std::vector<uint8_t>& message) {
    (void)destination;
    (void)message;
    // TODO: Send via SAM STREAM
    return true;
}
```

#### Line 316: `encrypted` and `blinded` in `publish_leaseset()`
```cpp
bool I2PManager::publish_leaseset(bool encrypted, bool blinded) {
    (void)encrypted;
    (void)blinded;
    // TODO: Implement leaseset publishing
    return true;
}
```

## ✅ Changes Summary

- ✅ **C4267 fixed**: Added `static_cast<int>()` for `send()` buffer length
- ✅ **C4100 fixed**: Marked 6 unreferenced parameters with `(void)`
- ✅ **No functional changes**: All code behavior remains identical
- ✅ **Future-proof**: Parameters kept for upcoming full I2P implementation

## 🧪 Testing

- Compiles cleanly on Windows (MSVC)
- Compiles cleanly on Linux (GCC/Clang)
- No change in functionality
- All existing tests pass

## 📝 Build Output

**Before:**
```
warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
warning C4100: 'local_port': unreferenced parameter
warning C4100: 'dest_public_key': unreferenced parameter
warning C4100: 'message': unreferenced parameter
warning C4100: 'destination': unreferenced parameter
warning C4100: 'blinded': unreferenced parameter
warning C4100: 'encrypted': unreferenced parameter
```

**After:**
```
(no warnings)
```

## 📊 Impact

- **Code quality**: ✅ Improved (clean compilation)
- **Performance**: ➡️ No change
- **Functionality**: ➡️ No change
- **Maintainability**: ✅ Improved (cleaner builds)

## 🔗 Related

- Part of ongoing effort to ensure clean compilation on all platforms
- Prepares codebase for full I2P implementation
- Follows best practices for stub/TODO implementations

---

**Ready to merge** ✅