### PR TITLE
3A: Merge ECH extension injection fix into phase2 branch

### DIFF
--- a/src/core/src/ncp_ech.cpp
+++ b/src/core/src/ncp_ech.cpp
@@ -6,6 +6,7 @@
 #include "../include/ncp_ech.hpp"
 #include <string>
 #include <algorithm>
+#include <cstring>
 
 #ifdef HAVE_OPENSSL
 #include <openssl/evp.h>
@@ -57,6 +58,148 @@ static OSSL_HPKE_SUITE make_suite(const HPKECipherSuite& cs) {
     suite.kdf_id  = hpke_kdf_to_id(cs.kdf_id);
     suite.aead_id = hpke_aead_to_id(cs.aead_id);
     return suite;
+}
+
+// ==================== ClientHello Parser Helpers ====================
+
+static bool find_extensions_block(
+    const uint8_t* data, size_t len,
+    size_t& ext_offset, size_t& ext_end
+) {
+    if (!data || len < 44) return false;
+    if (data[0] != 0x16) return false;           // ContentType: Handshake
+    if (data[5] != 0x01) return false;           // HandshakeType: ClientHello
+
+    size_t pos = 9;  // skip record header(5) + handshake header(4)
+
+    // ClientVersion
+    pos += 2; // [9..10]
+    if (pos > len) return false;
+
+    // Random
+    pos += 32; // [11..42]
+    if (pos >= len) return false;
+
+    // SessionID
+    uint8_t sid_len = data[pos];
+    pos += 1 + sid_len;
+    if (pos + 2 > len) return false;
+
+    // CipherSuites
+    uint16_t cs_len = (static_cast<uint16_t>(data[pos]) << 8) | data[pos + 1];
+    pos += 2 + cs_len;
+    if (pos + 1 > len) return false;
+
+    // CompressionMethods
+    uint8_t comp_len = data[pos];
+    pos += 1 + comp_len;
+    if (pos + 2 > len) return false;
+
+    // Extensions length field starts here
+    ext_offset = pos;
+    uint16_t exts_len = (static_cast<uint16_t>(data[pos]) << 8) | data[pos + 1];
+    pos += 2;
+
+    ext_end = pos + exts_len;
+    if (ext_end > len) {
+        ext_end = len;  // clamp
+    }
+
+    return true;
+}
+
+static std::vector<uint8_t> rewrite_sni(
+    const std::vector<uint8_t>& ch,
+    const std::string& new_name
+) {
+    size_t ext_offset = 0, ext_end = 0;
+    if (!find_extensions_block(ch.data(), ch.size(), ext_offset, ext_end)) {
+        return ch;
+    }
+
+    // Walk extensions to find SNI (type 0x0000)
+    size_t pos = ext_offset + 2;  // skip extensions_length
+    while (pos + 4 <= ext_end) {
+        uint16_t ext_type = (static_cast<uint16_t>(ch[pos]) << 8) | ch[pos + 1];
+        uint16_t ext_data_len = (static_cast<uint16_t>(ch[pos + 2]) << 8) | ch[pos + 3];
+        size_t ext_start = pos;
+
+        if (ext_type == 0x0000 && ext_data_len >= 5) {
+            // Found SNI extension
+            size_t sni_body = pos + 4;  // start of extension data
+            if (sni_body + 5 > ext_end) break;
+
+            size_t hn_len_offset = sni_body + 2 + 1;  // after sni_list_len + name_type
+            if (hn_len_offset + 2 > ext_end) break;
+            uint16_t old_hn_len = (static_cast<uint16_t>(ch[hn_len_offset]) << 8) |
+                                  ch[hn_len_offset + 1];
+            size_t hn_start = hn_len_offset + 2;
+            if (hn_start + old_hn_len > ext_end) break;
+
+            std::vector<uint8_t> result;
+            result.reserve(ch.size() - old_hn_len + new_name.size());
+
+            // Copy up to hostname
+            result.insert(result.end(), ch.begin(), ch.begin() + hn_start);
+            // Insert new hostname
+            result.insert(result.end(), new_name.begin(), new_name.end());
+            // Copy after old hostname
+            result.insert(result.end(),
+                          ch.begin() + hn_start + old_hn_len,
+                          ch.end());
+
+            int16_t delta = static_cast<int16_t>(new_name.size()) -
+                            static_cast<int16_t>(old_hn_len);
+
+            if (delta != 0) {
+                // Patch hostname_len
+                uint16_t new_hn_len = static_cast<uint16_t>(new_name.size());
+                result[hn_len_offset]     = static_cast<uint8_t>(new_hn_len >> 8);
+                result[hn_len_offset + 1] = static_cast<uint8_t>(new_hn_len & 0xFF);
+
+                // Patch sni_list_len
+                uint16_t old_list_len = (static_cast<uint16_t>(ch[sni_body]) << 8) |
+                                        ch[sni_body + 1];
+                uint16_t new_list_len = static_cast<uint16_t>(old_list_len + delta);
+                result[sni_body]     = static_cast<uint8_t>(new_list_len >> 8);
+                result[sni_body + 1] = static_cast<uint8_t>(new_list_len & 0xFF);
+
+                // Patch extension data length
+                uint16_t new_ext_data_len = static_cast<uint16_t>(ext_data_len + delta);
+                result[ext_start + 2] = static_cast<uint8_t>(new_ext_data_len >> 8);
+                result[ext_start + 3] = static_cast<uint8_t>(new_ext_data_len & 0xFF);
+
+                // Patch extensions_length
+                uint16_t old_exts_len = (static_cast<uint16_t>(ch[ext_offset]) << 8) |
+                                        ch[ext_offset + 1];
+                uint16_t new_exts_len = static_cast<uint16_t>(old_exts_len + delta);
+                result[ext_offset]     = static_cast<uint8_t>(new_exts_len >> 8);
+                result[ext_offset + 1] = static_cast<uint8_t>(new_exts_len & 0xFF);
+
+                // Patch Handshake length (3 bytes at offset 6..8)
+                uint32_t old_hs_len = (static_cast<uint32_t>(ch[6]) << 16) |
+                                      (static_cast<uint32_t>(ch[7]) << 8) |
+                                      static_cast<uint32_t>(ch[8]);
+                uint32_t new_hs_len = static_cast<uint32_t>(static_cast<int32_t>(old_hs_len) + delta);
+                result[6] = static_cast<uint8_t>((new_hs_len >> 16) & 0xFF);
+                result[7] = static_cast<uint8_t>((new_hs_len >> 8) & 0xFF);
+                result[8] = static_cast<uint8_t>(new_hs_len & 0xFF);
+
+                // Patch TLS record length (2 bytes at offset 3..4)
+                uint16_t old_rec_len = (static_cast<uint16_t>(ch[3]) << 8) |
+                                       static_cast<uint16_t>(ch[4]);
+                uint16_t new_rec_len = static_cast<uint16_t>(old_rec_len + delta);
+                result[3] = static_cast<uint8_t>(new_rec_len >> 8);
+                result[4] = static_cast<uint8_t>(new_rec_len & 0xFF);
+            }
+
+            return result;
+        }
+
+        pos += 4 + ext_data_len;
+    }
+
+    return ch;  // SNI not found, return unchanged
 }
 
 // ==================== ECHClientContext Implementation ====================
@@ -338,33 +481,99 @@ std::vector<uint8_t> apply_ech(
     const std::vector<uint8_t>& client_hello,
     const ECHConfig& config
 ) {
+    // Validate basic structure: TLS Handshake / ClientHello
+    if (client_hello.size() < 44) return client_hello;
+    if (client_hello[0] != 0x16) return client_hello;
+    if (client_hello[5] != 0x01) return client_hello;
+
+    size_t ext_offset = 0, ext_end = 0;
+    if (!find_extensions_block(client_hello.data(), client_hello.size(),
+                               ext_offset, ext_end)) {
+        return client_hello;
+    }
+
     ECHClientContext ctx;
     if (!ctx.init(config)) {
-        return client_hello;  // Return unmodified on failure
+        return client_hello;
     }
 
     std::vector<uint8_t> enc, encrypted;
-    std::vector<uint8_t> aad;  // Empty AAD for now
+    std::vector<uint8_t> aad = client_hello;  // use full outer CH as AAD
 
     if (!ctx.encrypt(client_hello, aad, enc, encrypted)) {
-        return client_hello;  // Return unmodified on failure
+        return client_hello;
     }
 
-    // Build ECH extension
-    std::vector<uint8_t> result;
-    // ECH extension type (0xfe0d for draft)
-    result.push_back(0xfe);
-    result.push_back(0x0d);
-    // Config ID
-    result.push_back(ctx.get_config_id());
-    // Enc
-    result.push_back(static_cast<uint8_t>(enc.size() >> 8));
-    result.push_back(static_cast<uint8_t>(enc.size() & 0xFF));
-    result.insert(result.end(), enc.begin(), enc.end());
-    // Encrypted payload
-    result.push_back(static_cast<uint8_t>(encrypted.size() >> 8));
-    result.push_back(static_cast<uint8_t>(encrypted.size() & 0xFF));
-    result.insert(result.end(), encrypted.begin(), encrypted.end());
+    const auto& cs = config.cipher_suites.empty()
+                     ? HPKECipherSuite() : config.cipher_suites[0];
+
+    std::vector<uint8_t> ech_payload;
+    ech_payload.reserve(1 + 4 + 1 + 2 + enc.size() + 2 + encrypted.size());
+
+    // type = 0 (outer)
+    ech_payload.push_back(0x00);
+
+    // cipher_suite: kdf_id (2) + aead_id (2)
+    uint16_t kdf_val = static_cast<uint16_t>(cs.kdf_id);
+    uint16_t aead_val = static_cast<uint16_t>(cs.aead_id);
+    ech_payload.push_back(static_cast<uint8_t>(kdf_val >> 8));
+    ech_payload.push_back(static_cast<uint8_t>(kdf_val & 0xFF));
+    ech_payload.push_back(static_cast<uint8_t>(aead_val >> 8));
+    ech_payload.push_back(static_cast<uint8_t>(aead_val & 0xFF));
+
+    // config_id
+    ech_payload.push_back(ctx.get_config_id());
+
+    // enc_len + enc
+    ech_payload.push_back(static_cast<uint8_t>(enc.size() >> 8));
+    ech_payload.push_back(static_cast<uint8_t>(enc.size() & 0xFF));
+    ech_payload.insert(ech_payload.end(), enc.begin(), enc.end());
+
+    // payload_len + payload
+    ech_payload.push_back(static_cast<uint8_t>(encrypted.size() >> 8));
+    ech_payload.push_back(static_cast<uint8_t>(encrypted.size() & 0xFF));
+    ech_payload.insert(ech_payload.end(), encrypted.begin(), encrypted.end());
+
+    // Wrap as TLS extension
+    std::vector<uint8_t> ech_ext;
+    ech_ext.reserve(4 + ech_payload.size());
+    ech_ext.push_back(0xfe);  // extension type: 0xfe0d (draft ECH)
+    ech_ext.push_back(0x0d);
+    uint16_t payload_len = static_cast<uint16_t>(ech_payload.size());
+    ech_ext.push_back(static_cast<uint8_t>(payload_len >> 8));
+    ech_ext.push_back(static_cast<uint8_t>(payload_len & 0xFF));
+    ech_ext.insert(ech_ext.end(), ech_payload.begin(), ech_payload.end());
+
+    std::vector<uint8_t> result = client_hello;
+
+    // Append ECH extension to extensions block
+    result.insert(result.begin() + ext_end,
+                  ech_ext.begin(), ech_ext.end());
+
+    uint16_t ech_ext_total = static_cast<uint16_t>(ech_ext.size());
+
+    // Patch extensions_length
+    uint16_t old_exts_len = (static_cast<uint16_t>(result[ext_offset]) << 8) |
+                            result[ext_offset + 1];
+    uint16_t new_exts_len = static_cast<uint16_t>(old_exts_len + ech_ext_total);
+    result[ext_offset]     = static_cast<uint8_t>(new_exts_len >> 8);
+    result[ext_offset + 1] = static_cast<uint8_t>(new_exts_len & 0xFF);
+
+    // Patch Handshake length (3 bytes at offset 6..8)
+    uint32_t old_hs_len = (static_cast<uint32_t>(result[6]) << 16) |
+                          (static_cast<uint32_t>(result[7]) << 8) |
+                          static_cast<uint32_t>(result[8]);
+    uint32_t new_hs_len = old_hs_len + ech_ext_total;
+    result[6] = static_cast<uint8_t>((new_hs_len >> 16) & 0xFF);
+    result[7] = static_cast<uint8_t>((new_hs_len >> 8) & 0xFF);
+    result[8] = static_cast<uint8_t>(new_hs_len & 0xFF);
+
+    // Patch TLS record length (2 bytes at offset 3..4)
+    uint16_t old_rec_len = (static_cast<uint16_t>(result[3]) << 8) |
+                           static_cast<uint16_t>(result[4]);
+    uint16_t new_rec_len = static_cast<uint16_t>(old_rec_len + ech_ext_total);
+    result[3] = static_cast<uint8_t>(new_rec_len >> 8);
+    result[4] = static_cast<uint8_t>(new_rec_len & 0xFF);
 
     return result;
 }


### PR DESCRIPTION
## What this PR does

Merges the corrected `apply_ech()` from `fix-ech-injection` into `phase2-tls-dpi-integration`.

### Bug fixed
**BEFORE:** `apply_ech()` returned only a raw ECH extension payload (`0xfe0d` + config_id + enc + ciphertext), completely replacing the ClientHello with a bare extension blob. When orchestrator called `data = apply_ech(data, config)`, the entire ClientHello was destroyed.

**AFTER:** `apply_ech()` now properly:
1. Validates TLS record header (ContentType=0x16, Handshake=0x01)
2. Parses ClientHello via `find_extensions_block()` to locate extensions list end
3. Encrypts original ClientHello as inner via HPKE
4. Builds ECHClientHello extension: `type(0xfe0d) + len + {type=0(outer), cipher_suite(kdf+aead), config_id, enc_len, enc, payload_len, payload}`
5. Appends ECH extension to existing extensions list at `ext_end`
6. Patches `extensions_length`, Handshake length (3-byte), TLS record length (2-byte)
7. Returns complete modified ClientHello with ECH injected

### New helpers added
- `find_extensions_block()` — parses ClientHello to find extensions offset/end
- `rewrite_sni()` — rewrites outer SNI hostname to ECHConfig.public_name (for future use)

Part of Phase 3 integration steps.