### PR TITLE
fix(i2p): thread-safety, SAM session leak, recv timeout, missing method, include path

### DIFF
--- a/src/core/include/ncp_i2p.hpp
+++ b/src/core/include/ncp_i2p.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <map>
+#include <mutex>
 #include <chrono>
 
 namespace ncp {
@@ -147,6 +148,7 @@ private:
     bool is_initialized_ = false;
     std::string current_dest_;
     std::map<std::string, TunnelInfo> tunnels_;
+    mutable std::mutex tunnels_mutex_;  // FIX #1: protects tunnels_ from data races
     
     // Internal tunnel operations
     std::vector<std::string> select_tunnel_hops(int length);


### PR DESCRIPTION
## I2P SAM Bridge Integration — 5 Bug Fixes

**CLOSED: All fixes now on `main`. FIX #1/#4 via earlier commits, FIX #2/#3/#5 via `ed0eb3f`.**

Fixes all identified issues in `i2p.cpp` / `ncp_i2p.hpp`.