### PR TITLE
fix: ECDH P-256 broken API, Kyber1024 missing decaps, encrypt/decrypt AAD binding

### DIFF
--- a/src/core/src/e2e.cpp
+++ b/src/core/src/e2e.cpp
@@ -9,6 +9,7 @@
 // OpenSSL for X448 and ECDH_P256
 #include <openssl/evp.h>
 #include <openssl/ec.h>
+#include <openssl/bn.h>
 #include <openssl/obj_mac.h>
 #include <openssl/err.h>
 
@@ -18,14 +19,30 @@
 
 namespace ncp {
 
-// Implementation details
+// ==================== RAII helpers for OpenSSL ====================
+
+struct EVP_PKEY_Deleter   { void operator()(EVP_PKEY* p)     const { if (p) EVP_PKEY_free(p); } };
+struct EVP_PKEY_CTX_Deleter { void operator()(EVP_PKEY_CTX* p) const { if (p) EVP_PKEY_CTX_free(p); } };
+struct EC_KEY_Deleter      { void operator()(EC_KEY* p)       const { if (p) EC_KEY_free(p); } };
+struct BN_Deleter          { void operator()(BIGNUM* p)       const { if (p) BN_free(p); } };
+struct EC_POINT_Deleter    { void operator()(EC_POINT* p)     const { if (p) EC_POINT_free(p); } };
+struct EC_GROUP_Deleter    { void operator()(EC_GROUP* p)     const { if (p) EC_GROUP_free(p); } };
+
+using UniqueEVP_PKEY     = std::unique_ptr<EVP_PKEY,     EVP_PKEY_Deleter>;
+using UniqueEVP_PKEY_CTX = std::unique_ptr<EVP_PKEY_CTX, EVP_PKEY_CTX_Deleter>;
+using UniqueEC_KEY       = std::unique_ptr<EC_KEY,       EC_KEY_Deleter>;
+using UniqueBN           = std::unique_ptr<BIGNUM,       BN_Deleter>;
+using UniqueEC_POINT     = std::unique_ptr<EC_POINT,     EC_POINT_Deleter>;
+
+// ==================== Implementation details ====================
+
 struct E2ESession::Impl {
     E2EConfig config;
     std::mutex mutex;
     std::string session_id;
 
     explicit Impl(const E2EConfig& cfg) : config(cfg) {
-            generate_session_id();
+        generate_session_id();
     }
 
     void generate_session_id();
@@ -42,13 +59,91 @@ void E2ESession::Impl::generate_session_id() {
     session_id = oss.str();
 }
 
-// E2ESession implementation
 E2ESession::E2ESession(const E2EConfig& config)
     : pImpl_(std::make_unique<Impl>(config)) {}
 
 E2ESession::~E2ESession() = default;
 
-// ===== Phase 2.3: generate_key_pair() — X448 + ECDH_P256 implementation =====
+// ==================== AAD builder ====================
+
+std::vector<uint8_t> E2ESession::build_aad() const {
+    // Bind ciphertexts to session context to prevent cross-session replay
+    const std::string& sid = pImpl_->session_id;
+    std::vector<uint8_t> aad;
+    // Tag: "ncp-e2e-v1\x00"
+    const char* tag = "ncp-e2e-v1";
+    aad.insert(aad.end(), tag, tag + 10);
+    aad.push_back(0x00);
+    // Session ID bytes
+    aad.insert(aad.end(), sid.begin(), sid.end());
+    return aad;
+}
+
+// ==================== EC P-256 helpers ====================
+
+/// Build EVP_PKEY from raw EC private key (32 bytes scalar) for P-256.
+static UniqueEVP_PKEY ec_p256_pkey_from_private_raw(
+    const uint8_t* priv_data, size_t priv_len
+) {
+    UniqueEC_KEY eckey(EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+    if (!eckey) throw std::runtime_error("EC_KEY_new_by_curve_name failed");
+
+    UniqueBN priv_bn(BN_bin2bn(priv_data, static_cast<int>(priv_len), nullptr));
+    if (!priv_bn) throw std::runtime_error("BN_bin2bn failed for EC private key");
+
+    if (EC_KEY_set_private_key(eckey.get(), priv_bn.get()) != 1) {
+        throw std::runtime_error("EC_KEY_set_private_key failed");
+    }
+
+    // Derive public key from private key: pub = priv * G
+    const EC_GROUP* group = EC_KEY_get0_group(eckey.get());
+    UniqueEC_POINT pub_point(EC_POINT_new(group));
+    if (!pub_point) throw std::runtime_error("EC_POINT_new failed");
+
+    if (EC_POINT_mul(group, pub_point.get(), priv_bn.get(), nullptr, nullptr, nullptr) != 1) {
+        throw std::runtime_error("EC_POINT_mul failed (deriving public key)");
+    }
+    if (EC_KEY_set_public_key(eckey.get(), pub_point.get()) != 1) {
+        throw std::runtime_error("EC_KEY_set_public_key failed");
+    }
+
+    UniqueEVP_PKEY pkey(EVP_PKEY_new());
+    if (!pkey) throw std::runtime_error("EVP_PKEY_new failed");
+    // EVP_PKEY_assign_EC_KEY takes ownership of eckey
+    if (EVP_PKEY_assign_EC_KEY(pkey.get(), eckey.release()) != 1) {
+        throw std::runtime_error("EVP_PKEY_assign_EC_KEY failed");
+    }
+    return pkey;
+}
+
+/// Build EVP_PKEY from uncompressed EC public key (65 bytes: 04 || X || Y) for P-256.
+static UniqueEVP_PKEY ec_p256_pkey_from_public_raw(
+    const uint8_t* pub_data, size_t pub_len
+) {
+    UniqueEC_KEY eckey(EC_KEY_new_by_curve_name(NID_X9_62_prime256v1));
+    if (!eckey) throw std::runtime_error("EC_KEY_new_by_curve_name failed");
+
+    const EC_GROUP* group = EC_KEY_get0_group(eckey.get());
+    UniqueEC_POINT point(EC_POINT_new(group));
+    if (!point) throw std::runtime_error("EC_POINT_new failed");
+
+    if (EC_POINT_oct2point(group, point.get(), pub_data, pub_len, nullptr) != 1) {
+        throw std::runtime_error("EC_POINT_oct2point failed (invalid public key)");
+    }
+    if (EC_KEY_set_public_key(eckey.get(), point.get()) != 1) {
+        throw std::runtime_error("EC_KEY_set_public_key failed");
+    }
+
+    UniqueEVP_PKEY pkey(EVP_PKEY_new());
+    if (!pkey) throw std::runtime_error("EVP_PKEY_new failed");
+    if (EVP_PKEY_assign_EC_KEY(pkey.get(), eckey.release()) != 1) {
+        throw std::runtime_error("EVP_PKEY_assign_EC_KEY failed");
+    }
+    return pkey;
+}
+
+// ==================== generate_key_pair() ====================
+
 KeyPair E2ESession::generate_key_pair() {
     std::lock_guard<std::mutex> lock(pImpl_->mutex);
 
@@ -65,98 +160,77 @@ KeyPair E2ESession::generate_key_pair() {
             break;
 
         case KeyExchangeProtocol::X448: {
-            // X448 key generation via OpenSSL EVP API
-            EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_X448, nullptr);
-            if (!pctx) {
-                throw std::runtime_error("Failed to create X448 context");
-            }
+            // X448 key generation via OpenSSL EVP API (raw keys supported)
+            UniqueEVP_PKEY_CTX pctx(EVP_PKEY_CTX_new_id(EVP_PKEY_X448, nullptr));
+            if (!pctx) throw std::runtime_error("Failed to create X448 context");
 
-            if (EVP_PKEY_keygen_init(pctx) <= 0) {
-                EVP_PKEY_CTX_free(pctx);
+            if (EVP_PKEY_keygen_init(pctx.get()) <= 0)
                 throw std::runtime_error("Failed to initialize X448 keygen");
-            }
 
-            EVP_PKEY* pkey = nullptr;
-            if (EVP_PKEY_keygen(pctx, &pkey) <= 0) {
-                EVP_PKEY_CTX_free(pctx);
+            EVP_PKEY* pkey_raw = nullptr;
+            if (EVP_PKEY_keygen(pctx.get(), &pkey_raw) <= 0)
                 throw std::runtime_error("Failed to generate X448 keypair");
-            }
-            EVP_PKEY_CTX_free(pctx);
+            UniqueEVP_PKEY pkey(pkey_raw);
 
             // Extract raw public key (56 bytes for X448)
             size_t pubkey_len = 56;
             kp.public_key = SecureMemory(pubkey_len);
-            if (EVP_PKEY_get_raw_public_key(pkey, kp.public_key.data(), &pubkey_len) <= 0) {
-                EVP_PKEY_free(pkey);
+            if (EVP_PKEY_get_raw_public_key(pkey.get(), kp.public_key.data(), &pubkey_len) <= 0)
                 throw std::runtime_error("Failed to extract X448 public key");
-            }
             kp.public_key.resize(pubkey_len);
 
             // Extract raw private key (56 bytes for X448)
             size_t privkey_len = 56;
             kp.private_key = SecureMemory(privkey_len);
-            if (EVP_PKEY_get_raw_private_key(pkey, kp.private_key.data(), &privkey_len) <= 0) {
-                EVP_PKEY_free(pkey);
+            if (EVP_PKEY_get_raw_private_key(pkey.get(), kp.private_key.data(), &privkey_len) <= 0)
                 throw std::runtime_error("Failed to extract X448 private key");
-            }
             kp.private_key.resize(privkey_len);
-
-            EVP_PKEY_free(pkey);
             break;
         }
 
         case KeyExchangeProtocol::ECDH_P256: {
-            // ECDH P-256 key generation via OpenSSL EVP API
-            EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr);
-            if (!pctx) {
-                throw std::runtime_error("Failed to create ECDH P-256 context");
-            }
+            // ECDH P-256: generate via EVP, extract via EC_KEY API
+            // (EVP_PKEY_get_raw_public/private_key does NOT work for EC keys)
+            UniqueEVP_PKEY_CTX pctx(EVP_PKEY_CTX_new_id(EVP_PKEY_EC, nullptr));
+            if (!pctx) throw std::runtime_error("Failed to create ECDH P-256 context");
 
-            if (EVP_PKEY_keygen_init(pctx) <= 0) {
-                EVP_PKEY_CTX_free(pctx);
+            if (EVP_PKEY_keygen_init(pctx.get()) <= 0)
                 throw std::runtime_error("Failed to initialize ECDH P-256 keygen");
-            }
 
-            // Set curve to P-256 (NID_X9_62_prime256v1)
-            if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, NID_X9_62_prime256v1) <= 0) {
-                EVP_PKEY_CTX_free(pctx);
+            if (EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx.get(), NID_X9_62_prime256v1) <= 0)
                 throw std::runtime_error("Failed to set ECDH P-256 curve");
-            }
 
-            EVP_PKEY* pkey = nullptr;
-            if (EVP_PKEY_keygen(pctx, &pkey) <= 0) {
-                EVP_PKEY_CTX_free(pctx);
+            EVP_PKEY* pkey_raw = nullptr;
+            if (EVP_PKEY_keygen(pctx.get(), &pkey_raw) <= 0)
                 throw std::runtime_error("Failed to generate ECDH P-256 keypair");
-            }
-            EVP_PKEY_CTX_free(pctx);
+            UniqueEVP_PKEY pkey(pkey_raw);
 
-            // Extract public key (uncompressed point: 0x04 + 32 bytes X + 32 bytes Y = 65 bytes)
-            size_t pubkey_len = 0;
-            if (EVP_PKEY_get_raw_public_key(pkey, nullptr, &pubkey_len) <= 0) {
-                EVP_PKEY_free(pkey);
-                throw std::runtime_error("Failed to query ECDH P-256 public key size");
-            }
+            // Get EC_KEY from EVP_PKEY
+            const EC_KEY* eckey = EVP_PKEY_get0_EC_KEY(pkey.get());
+            if (!eckey) throw std::runtime_error("EVP_PKEY_get0_EC_KEY failed");
 
+            const EC_GROUP* group = EC_KEY_get0_group(eckey);
+
+            // Extract public key as uncompressed point (04 || X || Y = 65 bytes)
+            const EC_POINT* pub_point = EC_KEY_get0_public_key(eckey);
+            if (!pub_point) throw std::runtime_error("EC_KEY_get0_public_key returned null");
+
+            size_t pubkey_len = EC_POINT_point2oct(
+                group, pub_point, POINT_CONVERSION_UNCOMPRESSED, nullptr, 0, nullptr
+            );
             kp.public_key = SecureMemory(pubkey_len);
-            if (EVP_PKEY_get_raw_public_key(pkey, kp.public_key.data(), &pubkey_len) <= 0) {
-                EVP_PKEY_free(pkey);
-                throw std::runtime_error("Failed to extract ECDH P-256 public key");
-            }
+            EC_POINT_point2oct(
+                group, pub_point, POINT_CONVERSION_UNCOMPRESSED,
+                kp.public_key.data(), pubkey_len, nullptr
+            );
 
-            // Extract private key (32 bytes scalar)
-            size_t privkey_len = 0;
-            if (EVP_PKEY_get_raw_private_key(pkey, nullptr, &privkey_len) <= 0) {
-                EVP_PKEY_free(pkey);
-                throw std::runtime_error("Failed to query ECDH P-256 private key size");
-            }
+            // Extract private key as raw scalar (32 bytes)
+            const BIGNUM* priv_bn = EC_KEY_get0_private_key(eckey);
+            if (!priv_bn) throw std::runtime_error("EC_KEY_get0_private_key returned null");
 
-            kp.private_key = SecureMemory(privkey_len);
-            if (EVP_PKEY_get_raw_private_key(pkey, kp.private_key.data(), &privkey_len) <= 0) {
-                EVP_PKEY_free(pkey);
-                throw std::runtime_error("Failed to extract ECDH P-256 private key");
-            }
-
-            EVP_PKEY_free(pkey);
+            int privkey_len = BN_num_bytes(priv_bn);
+            kp.private_key = SecureMemory(static_cast<size_t>(privkey_len));
+            BN_bn2bin(priv_bn, kp.private_key.data());
             break;
         }
 
@@ -164,9 +238,7 @@ KeyPair E2ESession::generate_key_pair() {
 #ifdef HAVE_LIBOQS
             {
                 OQS_KEM *kem = OQS_KEM_new(OQS_KEM_alg_kyber_1024);
-                if (!kem) {
-                    throw std::runtime_error("Failed to initialize Kyber1024 KEM");
-                }
+                if (!kem) throw std::runtime_error("Failed to initialize Kyber1024 KEM");
 
                 kp.public_key = SecureMemory(kem->length_public_key);
                 kp.private_key = SecureMemory(kem->length_secret_key);
@@ -175,7 +247,6 @@ KeyPair E2ESession::generate_key_pair() {
                     OQS_KEM_free(kem);
                     throw std::runtime_error("Failed to generate Kyber1024 keypair");
                 }
-
                 OQS_KEM_free(kem);
             }
 #else
@@ -187,7 +258,8 @@ KeyPair E2ESession::generate_key_pair() {
     return kp;
 }
 
-// ===== Phase 2.3: compute_shared_secret() — X448 + ECDH_P256 implementation =====
+// ==================== compute_shared_secret() — DH-based only ====================
+
 SecureMemory E2ESession::compute_shared_secret(
     const KeyPair& local_keypair,
     const std::vector<uint8_t>& peer_public_key
@@ -200,199 +272,184 @@ SecureMemory E2ESession::compute_shared_secret(
 
     switch (local_keypair.protocol) {
         case KeyExchangeProtocol::X25519: {
-            if (peer_public_key.size() != crypto_box_PUBLICKEYBYTES) {
+            if (peer_public_key.size() != crypto_box_PUBLICKEYBYTES)
                 throw std::runtime_error("Invalid peer public key size for X25519");
-            }
 
             SecureMemory shared_secret(crypto_scalarmult_BYTES);
-            if (crypto_scalarmult(shared_secret.data(), 
+            if (crypto_scalarmult(shared_secret.data(),
                                   local_keypair.private_key.data(),
-                                  peer_public_key.data()) != 0) {
+                                  peer_public_key.data()) != 0)
                 throw std::runtime_error("Failed to compute X25519 shared secret");
-            }
             return shared_secret;
         }
 
         case KeyExchangeProtocol::X448: {
-            // X448 shared secret computation via OpenSSL EVP_PKEY_derive
-            if (peer_public_key.size() != 56) {
+            if (peer_public_key.size() != 56)
                 throw std::runtime_error("Invalid peer public key size for X448 (expected 56 bytes)");
-            }
 
-            // Load local private key
-            EVP_PKEY* local_pkey = EVP_PKEY_new_raw_private_key(
+            // X448: raw key API works fine
+            UniqueEVP_PKEY local_pkey(EVP_PKEY_new_raw_private_key(
                 EVP_PKEY_X448, nullptr,
                 local_keypair.private_key.data(),
                 local_keypair.private_key.size()
-            );
-            if (!local_pkey) {
+            ));
+            if (!local_pkey)
                 throw std::runtime_error("Failed to load X448 local private key");
-            }
 
-            // Load peer public key
-            EVP_PKEY* peer_pkey = EVP_PKEY_new_raw_public_key(
+            UniqueEVP_PKEY peer_pkey(EVP_PKEY_new_raw_public_key(
                 EVP_PKEY_X448, nullptr,
                 peer_public_key.data(),
                 peer_public_key.size()
-            );
-            if (!peer_pkey) {
-                EVP_PKEY_free(local_pkey);
+            ));
+            if (!peer_pkey)
                 throw std::runtime_error("Failed to load X448 peer public key");
-            }
 
-            // Derive shared secret
-            EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new(local_pkey, nullptr);
-            if (!ctx) {
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
-                throw std::runtime_error("Failed to create X448 derive context");
-            }
-
-            if (EVP_PKEY_derive_init(ctx) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            UniqueEVP_PKEY_CTX ctx(EVP_PKEY_CTX_new(local_pkey.get(), nullptr));
+            if (!ctx) throw std::runtime_error("Failed to create X448 derive context");
+            if (EVP_PKEY_derive_init(ctx.get()) <= 0)
                 throw std::runtime_error("Failed to initialize X448 derive");
-            }
-
-            if (EVP_PKEY_derive_set_peer(ctx, peer_pkey) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            if (EVP_PKEY_derive_set_peer(ctx.get(), peer_pkey.get()) <= 0)
                 throw std::runtime_error("Failed to set X448 peer key");
-            }
 
             size_t secret_len = 0;
-            if (EVP_PKEY_derive(ctx, nullptr, &secret_len) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            if (EVP_PKEY_derive(ctx.get(), nullptr, &secret_len) <= 0)
                 throw std::runtime_error("Failed to query X448 shared secret size");
-            }
 
             SecureMemory shared_secret(secret_len);
-            if (EVP_PKEY_derive(ctx, shared_secret.data(), &secret_len) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            if (EVP_PKEY_derive(ctx.get(), shared_secret.data(), &secret_len) <= 0)
                 throw std::runtime_error("Failed to derive X448 shared secret");
-            }
-
-            EVP_PKEY_CTX_free(ctx);
-            EVP_PKEY_free(local_pkey);
-            EVP_PKEY_free(peer_pkey);
 
             return shared_secret;
         }
 
         case KeyExchangeProtocol::ECDH_P256: {
-            // ECDH P-256 shared secret computation via OpenSSL EVP_PKEY_derive
-            if (peer_public_key.size() != 65) {  // Uncompressed point: 0x04 + 32 + 32
+            // ECDH P-256: reconstruct EVP_PKEY via EC_KEY API
+            // (EVP_PKEY_new_raw_private_key(EVP_PKEY_EC) does NOT work)
+            if (peer_public_key.size() != 65)
                 throw std::runtime_error("Invalid peer public key size for ECDH P-256 (expected 65 bytes)");
-            }
 
-            // Load local private key
-            EVP_PKEY* local_pkey = EVP_PKEY_new_raw_private_key(
-                EVP_PKEY_EC, nullptr,
+            auto local_pkey = ec_p256_pkey_from_private_raw(
                 local_keypair.private_key.data(),
                 local_keypair.private_key.size()
             );
-            if (!local_pkey) {
-                throw std::runtime_error("Failed to load ECDH P-256 local private key");
-            }
 
-            // Load peer public key
-            EVP_PKEY* peer_pkey = EVP_PKEY_new_raw_public_key(
-                EVP_PKEY_EC, nullptr,
+            auto peer_pkey = ec_p256_pkey_from_public_raw(
                 peer_public_key.data(),
                 peer_public_key.size()
             );
-            if (!peer_pkey) {
-                EVP_PKEY_free(local_pkey);
-                throw std::runtime_error("Failed to load ECDH P-256 peer public key");
-            }
 
-            // Derive shared secret
-            EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new(local_pkey, nullptr);
-            if (!ctx) {
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
-                throw std::runtime_error("Failed to create ECDH P-256 derive context");
-            }
-
-            if (EVP_PKEY_derive_init(ctx) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            UniqueEVP_PKEY_CTX ctx(EVP_PKEY_CTX_new(local_pkey.get(), nullptr));
+            if (!ctx) throw std::runtime_error("Failed to create ECDH P-256 derive context");
+            if (EVP_PKEY_derive_init(ctx.get()) <= 0)
                 throw std::runtime_error("Failed to initialize ECDH P-256 derive");
-            }
-
-            if (EVP_PKEY_derive_set_peer(ctx, peer_pkey) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            if (EVP_PKEY_derive_set_peer(ctx.get(), peer_pkey.get()) <= 0)
                 throw std::runtime_error("Failed to set ECDH P-256 peer key");
-            }
 
             size_t secret_len = 0;
-            if (EVP_PKEY_derive(ctx, nullptr, &secret_len) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            if (EVP_PKEY_derive(ctx.get(), nullptr, &secret_len) <= 0)
                 throw std::runtime_error("Failed to query ECDH P-256 shared secret size");
-            }
 
             SecureMemory shared_secret(secret_len);
-            if (EVP_PKEY_derive(ctx, shared_secret.data(), &secret_len) <= 0) {
-                EVP_PKEY_CTX_free(ctx);
-                EVP_PKEY_free(local_pkey);
-                EVP_PKEY_free(peer_pkey);
+            if (EVP_PKEY_derive(ctx.get(), shared_secret.data(), &secret_len) <= 0)
                 throw std::runtime_error("Failed to derive ECDH P-256 shared secret");
-            }
-
-            EVP_PKEY_CTX_free(ctx);
-            EVP_PKEY_free(local_pkey);
-            EVP_PKEY_free(peer_pkey);
 
             return shared_secret;
         }
 
         case KeyExchangeProtocol::Kyber1024:
-#ifdef HAVE_LIBOQS
-            {
-                OQS_KEM *kem = OQS_KEM_new(OQS_KEM_alg_kyber_1024);
-                if (!kem) {
-                    throw std::runtime_error("Failed to initialize Kyber1024 KEM");
-                }
-
-                SecureMemory ciphertext(kem->length_ciphertext);
-                SecureMemory shared_secret(kem->length_shared_secret);
-
-                if (OQS_KEM_encaps(kem, ciphertext.data(), shared_secret.data(),
-                                   peer_public_key.data()) != OQS_SUCCESS) {
-                    OQS_KEM_free(kem);
-                    throw std::runtime_error("Failed to encapsulate with Kyber1024");
-                }
-
-                OQS_KEM_free(kem);
-                return shared_secret;
-            }
-#else
-            throw std::runtime_error("Kyber1024 requires liboqs - recompile with HAVE_LIBOQS");
-#endif
+            throw std::runtime_error(
+                "Kyber1024 is a KEM, not DH. Use encapsulate_shared_secret() / "
+                "decapsulate_shared_secret() instead of compute_shared_secret()"
+            );
     }
 
     throw std::runtime_error("Unsupported key exchange protocol");
 }
+
+// ==================== Kyber KEM: encapsulate / decapsulate ====================
+
+KEMEncapsResult E2ESession::encapsulate_shared_secret(
+    const std::vector<uint8_t>& peer_public_key
+) {
+    std::lock_guard<std::mutex> lock(pImpl_->mutex);
+
+    if (pImpl_->config.key_exchange != KeyExchangeProtocol::Kyber1024)
+        throw std::runtime_error("encapsulate_shared_secret() is only for Kyber KEM");
+
+#ifdef HAVE_LIBOQS
+    OQS_KEM *kem = OQS_KEM_new(OQS_KEM_alg_kyber_1024);
+    if (!kem) throw std::runtime_error("Failed to initialize Kyber1024 KEM");
+
+    if (peer_public_key.size() != kem->length_public_key) {
+        OQS_KEM_free(kem);
+        throw std::runtime_error("Invalid Kyber1024 public key size");
+    }
+
+    KEMEncapsResult result;
+    result.ciphertext.resize(kem->length_ciphertext);
+    result.shared_secret = SecureMemory(kem->length_shared_secret);
+
+    if (OQS_KEM_encaps(kem, result.ciphertext.data(),
+                       result.shared_secret.data(),
+                       peer_public_key.data()) != OQS_SUCCESS) {
+        OQS_KEM_free(kem);
+        throw std::runtime_error("Kyber1024 encapsulation failed");
+    }
+
+    OQS_KEM_free(kem);
+    return result;
+#else
+    throw std::runtime_error("Kyber1024 requires liboqs - recompile with HAVE_LIBOQS");
+#endif
+}
+
+SecureMemory E2ESession::decapsulate_shared_secret(
+    const KeyPair& local_keypair,
+    const std::vector<uint8_t>& ciphertext
+) {
+    std::lock_guard<std::mutex> lock(pImpl_->mutex);
+
+    if (local_keypair.protocol != KeyExchangeProtocol::Kyber1024)
+        throw std::runtime_error("decapsulate_shared_secret() is only for Kyber KEM");
+
+#ifdef HAVE_LIBOQS
+    OQS_KEM *kem = OQS_KEM_new(OQS_KEM_alg_kyber_1024);
+    if (!kem) throw std::runtime_error("Failed to initialize Kyber1024 KEM");
+
+    if (ciphertext.size() != kem->length_ciphertext) {
+        OQS_KEM_free(kem);
+        throw std::runtime_error("Invalid Kyber1024 ciphertext size");
+    }
+    if (local_keypair.private_key.size() != kem->length_secret_key) {
+        OQS_KEM_free(kem);
+        throw std::runtime_error("Invalid Kyber1024 secret key size");
+    }
+
+    SecureMemory shared_secret(kem->length_shared_secret);
+
+    if (OQS_KEM_decaps(kem, shared_secret.data(),
+                       ciphertext.data(),
+                       local_keypair.private_key.data()) != OQS_SUCCESS) {
+        OQS_KEM_free(kem);
+        throw std::runtime_error("Kyber1024 decapsulation failed");
+    }
+
+    OQS_KEM_free(kem);
+    return shared_secret;
+#else
+    throw std::runtime_error("Kyber1024 requires liboqs - recompile with HAVE_LIBOQS");
+#endif
+}
+
+// ==================== derive_keys() ====================
 
 SecureMemory E2ESession::derive_keys(
     const SecureMemory& shared_secret,
     const std::string& context,
     size_t key_length
 ) {
-    if (key_length < crypto_aead_xchacha20poly1305_ietf_KEYBYTES) {
+    if (key_length < crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
         throw std::runtime_error("Key length too small");
-    }
 
     SecureMemory derived_key(key_length);
 
@@ -434,18 +491,20 @@ SecureMemory E2ESession::derive_keys(
     return derived_key;
 }
 
+// ==================== encrypt_message() — with AAD ====================
+
 EncryptedMessage E2ESession::encrypt_message(
     const std::vector<uint8_t>& plaintext,
     const SecureMemory& encryption_key
 ) {
-    if (encryption_key.size() != crypto_aead_xchacha20poly1305_ietf_KEYBYTES) {
+    if (encryption_key.size() != crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
         throw std::runtime_error("Invalid encryption key size");
-    }
 
-    // Guard against integer overflow: plaintext + ABYTES must not overflow
-    if (plaintext.size() > SIZE_MAX - crypto_aead_xchacha20poly1305_ietf_ABYTES) {
+    if (plaintext.size() > SIZE_MAX - crypto_aead_xchacha20poly1305_ietf_ABYTES)
         throw std::runtime_error("Plaintext too large");
-    }
+
+    // Build AAD from session context to bind ciphertext to this session
+    auto aad = build_aad();
 
     EncryptedMessage msg;
     msg.nonce.resize(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
@@ -457,7 +516,7 @@ EncryptedMessage E2ESession::encrypt_message(
     if (crypto_aead_xchacha20poly1305_ietf_encrypt(
             msg.ciphertext.data(), &ciphertext_len,
             plaintext.data(), plaintext.size(),
-            nullptr, 0,
+            aad.data(), aad.size(),
             nullptr,
             msg.nonce.data(),
             encryption_key.data()) != 0) {
@@ -470,22 +529,23 @@ EncryptedMessage E2ESession::encrypt_message(
     return msg;
 }
 
+// ==================== decrypt_message() — with AAD ====================
+
 std::vector<uint8_t> E2ESession::decrypt_message(
     const EncryptedMessage& message,
     const SecureMemory& decryption_key
 ) {
-    if (decryption_key.size() != crypto_aead_xchacha20poly1305_ietf_KEYBYTES) {
+    if (decryption_key.size() != crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
         throw std::runtime_error("Invalid decryption key size");
-    }
 
-    if (message.nonce.size() != crypto_aead_xchacha20poly1305_ietf_NPUBBYTES) {
+    if (message.nonce.size() != crypto_aead_xchacha20poly1305_ietf_NPUBBYTES)
         throw std::runtime_error("Invalid nonce size");
-    }
 
-    // Ciphertext must contain at least the authentication tag
-    if (message.ciphertext.size() < crypto_aead_xchacha20poly1305_ietf_ABYTES) {
+    if (message.ciphertext.size() < crypto_aead_xchacha20poly1305_ietf_ABYTES)
         throw std::runtime_error("Ciphertext too short - missing authentication tag");
-    }
+
+    // Rebuild same AAD that was used during encryption
+    auto aad = build_aad();
 
     std::vector<uint8_t> plaintext(message.ciphertext.size());
     unsigned long long plaintext_len;
@@ -494,10 +554,9 @@ std::vector<uint8_t> E2ESession::decrypt_message(
             plaintext.data(), &plaintext_len,
             nullptr,
             message.ciphertext.data(), message.ciphertext.size(),
-            nullptr, 0,
+            aad.data(), aad.size(),
             message.nonce.data(),
             decryption_key.data()) != 0) {
-        // Zero the plaintext buffer before throwing to avoid leaking partial data
         sodium_memzero(plaintext.data(), plaintext.size());
         throw std::runtime_error("Decryption failed or authentication tag invalid");
     }


### PR DESCRIPTION
## Summary

Fixes 3 critical (🔴) and 1 important (🟠) bugs in `e2e.cpp` — End-to-End Encryption module.

---

### 🔴 Bug 1: ECDH P-256 — `EVP_PKEY_new_raw_private_key(EVP_PKEY_EC)` doesn't work

**Problem:** `compute_shared_secret()` for ECDH_P256 calls `EVP_PKEY_new_raw_private_key(EVP_PKEY_EC, ...)` and `EVP_PKEY_new_raw_public_key(EVP_PKEY_EC, ...)`. These functions only support "raw key" algorithms (X25519, X448, Ed25519, Ed448). For EC keys they always return `nullptr` → throw → **ECDH P-256 key exchange completely non-functional**.

**Fix:** Reconstruct `EVP_PKEY` from raw bytes using the proper EC_KEY API:
- Private key: `BN_bin2bn()` → `EC_KEY_set_private_key()` → derive public point via `EC_POINT_mul()` → `EVP_PKEY_assign_EC_KEY()`
- Public key: `EC_POINT_oct2point()` → `EC_KEY_set_public_key()` → `EVP_PKEY_assign_EC_KEY()`

Extracted into reusable helpers: `ec_p256_pkey_from_private_raw()` / `ec_p256_pkey_from_public_raw()`

---

### 🔴 Bug 2: ECDH P-256 — `generate_key_pair()` uses unsupported raw key extraction

**Problem:** `generate_key_pair()` for ECDH_P256 calls `EVP_PKEY_get_raw_public_key()` / `EVP_PKEY_get_raw_private_key()`, which don't work for EC keys (same reason as Bug 1).

**Fix:** Extract keys via EC_KEY API:
- Public key: `EC_POINT_point2oct()` with `POINT_CONVERSION_UNCOMPRESSED` (65 bytes: `04 || X || Y`)
- Private key: `BN_bn2bin()` from `EC_KEY_get0_private_key()` (32-byte scalar)

---

### 🔴 Bug 3: Kyber1024 — `compute_shared_secret()` does encaps only, no decaps

**Problem:** Correct KEM protocol:
1. Alice → `keypair()` → `(pk, sk)`, sends `pk` to Bob
2. Bob → `encaps(pk)` → `(ciphertext, shared_secret)`, sends `ciphertext` to Alice
3. Alice → `decaps(sk, ciphertext)` → `shared_secret`

But `compute_shared_secret()` always calls `OQS_KEM_encaps()` — that's Bob's step only. There's no decaps code. Both sides calling encaps → **different shared secrets** → Kyber key exchange completely broken.

**Fix:**
- `compute_shared_secret()` for Kyber now throws with a clear error directing users to the proper KEM API
- New `encapsulate_shared_secret(peer_pk)` → returns `KEMEncapsResult{shared_secret, ciphertext}` (Bob's side)
- New `decapsulate_shared_secret(local_keypair, ciphertext)` → returns `shared_secret` (Alice's side)
- New `KEMEncapsResult` struct in header

**Usage:**
```cpp
// Alice: generate keypair, send pk to Bob
auto alice_kp = alice_session.generate_key_pair();

// Bob: encapsulate with Alice's public key
auto [shared_secret_bob, ciphertext] = bob_session.encapsulate_shared_secret(
    {alice_kp.public_key.data(), alice_kp.public_key.data() + alice_kp.public_key.size()}
);
// Bob sends ciphertext to Alice

// Alice: decapsulate with her secret key
auto shared_secret_alice = alice_session.decapsulate_shared_secret(alice_kp, ciphertext);
// shared_secret_alice == shared_secret_bob ✓
```

---

### 🟠 Bug 4: encrypt/decrypt — no AAD (cross-session replay possible)

**Problem:** `encrypt_message()` and `decrypt_message()` pass `nullptr, 0` as AAD to `crypto_aead_xchacha20poly1305_ietf_encrypt/decrypt`. Without AAD, ciphertexts are not bound to any context — an attacker can replay ciphertexts from one session into another.

**Fix:**
- New private method `build_aad()` constructs AAD as `"ncp-e2e-v1" || 0x00 || session_id`
- Both `encrypt_message()` and `decrypt_message()` now pass this AAD
- Ciphertexts are cryptographically bound to the session that created them

---

### 🟡 Note: No ratcheting / forward secrecy (not addressed)

The session uses a single static key for all messages. No Double Ratchet, no key rotation. This is a design-level enhancement tracked separately — requires significant architectural changes (Signal-style ratchet with header keys, chain keys, skipped message keys).

---

### Additional improvements

- RAII wrappers (`UniqueEVP_PKEY`, `UniqueEC_KEY`, `UniqueBN`, etc.) replace manual `EVP_PKEY_free()` cleanup — eliminates resource leaks on error paths
- `#include <openssl/bn.h>` added (was missing, needed for `BN_bin2bn` / `BN_bn2bin`)

### Files changed

| File | Change |
|------|--------|
| `src/core/include/ncp_e2e.hpp` | Added `KEMEncapsResult`, `encapsulate_shared_secret()`, `decapsulate_shared_secret()`, `build_aad()` |
| `src/core/src/e2e.cpp` | Fixed all 4 bugs, added RAII wrappers, EC P-256 helpers |
