### PR TITLE
fix(probe_resist): broken HMAC fallback, csprng, const-time compare, JA3 thread-safety, nonce O(n)

### DIFF
--- a/src/core/include/ncp_probe_resist.hpp
+++ b/src/core/include/ncp_probe_resist.hpp
@@ -314,8 +314,10 @@ private:
     ProbeEventCallback event_callback_;
 
     // Nonce window: hash → expiry time
+    // FIX #25: hex_str stored alongside hash to avoid O(n) recomputation on eviction
     struct NonceEntry {
-        std::array<uint8_t, 32> hash;  // SHA256 of nonce
+        std::array<uint8_t, 32> hash;  // raw nonce bytes (zero-padded)
+        std::string hex_str;           // pre-computed hex for O(1) set erase
         std::chrono::steady_clock::time_point expiry;
     };
     std::deque<NonceEntry> nonce_window_;
@@ -340,6 +342,7 @@ private:
     // JA3 sets
     std::unordered_set<std::string> ja3_allowlist_;
     std::unordered_set<std::string> ja3_scanner_set_;
+    mutable std::mutex ja3_mutex_;  // FIX #24: protects ja3_allowlist_ and ja3_scanner_set_
 };
 
 } // namespace DPI


### PR DESCRIPTION
## ncp_probe_resist.cpp — 5 Bug Fixes

---

### 🔴 FIX #21 (Critical) — Fallback HMAC without OpenSSL is cryptographically broken

**Problem:** When `HAVE_OPENSSL` is not defined, `compute_hmac()` uses `XOR key⊕data` — this is not an HMAC, not even a MAC. An attacker can trivially forge packets. The entire ProbeResist auth system becomes meaningless without OpenSSL.

**Fix:** Replaced with `crypto_auth_hmacsha256_init/update/final()` from libsodium (already linked project-wide). Uses the streaming API to handle arbitrary key lengths per RFC 2104. HMAC state is wiped with `sodium_memzero()` after use to prevent key material leakage from stack.

---

### 🟠 FIX #22 (Logic) — `csprng_fill()` duplicates and is inferior to sodium

**Problem:** Code uses raw `open("/dev/urandom")` with:
- No check that `fd >= 0` actually succeeded (if it returns -1, buffer stays **uninitialized**)
- Duplicate implementation of what `randombytes_buf()` already does
- Inconsistency with rest of codebase (`ncp_paranoid.cpp` uses sodium everywhere)

**Fix:** Replaced entire `csprng_fill()` body with `randombytes_buf(buf, len)`. Cross-platform, never fails, zero fd leak risk. Removed dead platform-specific `#ifdef` blocks (`BCryptGenRandom`, `/dev/urandom`).

---

### 🟠 FIX #23 (Logic) — Constant-time HMAC comparison: `volatile` may not work

**Problem:** 
```cpp
volatile uint8_t accum = 0;
for (...) accum |= a[i] ^ b[i];
hmac_valid = (accum == 0);
```
The `volatile` qualifier only prevents the compiler from eliding the `accum` variable itself. The compiler can still:
- Unroll the loop with early-exit
- Optimize the final comparison `accum == 0` into a branch after partial XOR
- Reorder operations around the volatile access

This is a known pitfall — `volatile` does **not** guarantee constant-time execution.

**Fix:** Replaced with `sodium_memcmp(a, b, len)` which is **guaranteed** constant-time by libsodium (uses inline asm barriers on supported platforms). Applied in both `process_connection()` and `verify_auth()`.

---

### 🟡 FIX #24 (Quality) — `ja3_allowlist_` and `ja3_scanner_set_` not thread-safe

**Problem:** `std::unordered_set` is modified by `add_ja3_allowlist()`, `remove_ja3_allowlist()`, and `set_config()`, while read concurrently by `process_connection()` → `is_ja3_allowed()` / `is_known_scanner()`. No mutex → data race → UB.

**Fix:** Added `mutable std::mutex ja3_mutex_` to `ProbeResist` (in `.hpp`). All JA3 set access now locks `ja3_mutex_`:
- `is_ja3_allowed()` — read lock
- `is_known_scanner()` — read lock
- `add_ja3_allowlist()` — write lock
- `remove_ja3_allowlist()` — write lock
- `set_config()` — write lock (when rebuilding sets)

---

### 🟡 FIX #25 (Quality) — Nonce eviction O(n) hex scanning

**Problem:** `check_and_record_nonce()` and `evict_expired_nonces()` call `bytes_to_hex(nonce_window_.front().hash.data(), ...)` on **every eviction**. With `nonce_window_size=100000`, a burst of expirations triggers 100k `std::ostringstream` + hex format operations.

**Fix:** Added `std::string hex_str` field to `NonceEntry` struct (in `.hpp`). Hex is computed once at insertion time and stored alongside the entry. Eviction now does `nonce_set_.erase(entry.hex_str)` — O(1) per entry, no recomputation.

---

### Files changed
- `src/core/include/ncp_probe_resist.hpp` — added `std::string hex_str` to `NonceEntry`, added `mutable std::mutex ja3_mutex_`
- `src/core/src/ncp_probe_resist.cpp` — all 5 fixes applied
