### PR TITLE
ci: incremental code-quality analysis (clang-format/tidy, cppcheck, lizard, CodeQL)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+# NCP code style — enforced incrementally by .github/workflows/code-quality.yml
+# (only lines touched in a PR are checked).
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+PointerAlignment: Left
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBraces: Attach
+NamespaceIndentation: None
+FixNamespaceComments: false
+SpaceAfterCStyleCast: false
+IncludeBlocks: Preserve
+SortIncludes: false
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,25 @@
+# NCP clang-tidy profile — run incrementally on PR-changed files by
+# .github/workflows/code-quality.yml. Kept moderate on purpose: no magic-number
+# / identifier-length noise, no forced trailing return types.
+Checks: >
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  concurrency-*,
+  misc-*,
+  -misc-unused-parameters,
+  -misc-no-recursion,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  portability-*,
+  readability-*,
+  -readability-magic-numbers,
+  -readability-identifier-length,
+  -readability-function-size,
+  -readability-uppercase-literal-suffix,
+  -readability-braces-around-statements
+WarningsAsErrors: ''
+HeaderFilterRegex: '(src|include)/.*'
+CheckOptions:
+  - key: readability-function-size.LineThreshold
+    value: '400'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,139 @@
+name: Code Quality
+
+# Incremental code-quality analysis (Designite-style): on PRs only the lines
+# you actually changed are flagged — reviewdog posts findings as PR review
+# comments (filter-mode: added). Nothing here blocks the build; treat findings
+# as review guidance. Tighten fail_level later if you want a hard gate.
+
+on:
+  pull_request:
+    branches: [main, master, develop]
+  push:
+    branches: [main, master, develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: code-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changed C++ files
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.list.outputs.files }}
+      any: ${{ steps.list.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: list
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE=$(git rev-parse HEAD~1 2>/dev/null || echo HEAD)
+          fi
+          files=$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD"             -- 'src/*.cpp' 'src/*.hpp' 'src/*.h' 'src/*.cc' | tr '\n' ' ')
+          echo "Changed C++ files: $files"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          if [ -n "$files" ]; then echo 'any=true' >> "$GITHUB_OUTPUT";
+          else echo 'any=false' >> "$GITHUB_OUTPUT"; fi
+
+  clang-format:
+    name: clang-format (changed lines)
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-clang-format@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: added
+          fail_level: none
+          level: warning
+          workdir: ./src
+          clang_format_version: '18'
+
+  cppcheck:
+    name: cppcheck (changed files)
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+      - name: Run cppcheck
+        env:
+          FILES: ${{ needs.changes.outputs.files }}
+        run: |
+          srcs=''
+          for f in $FILES; do case "$f" in *.cpp|*.cc) srcs="$srcs $f";; esac; done
+          [ -z "$srcs" ] && { echo 'No .cpp files changed'; exit 0; }
+          cppcheck --std=c++17 --quiet --inline-suppr             --enable=warning,performance,portability             -I src/core/include -I src             --template=gcc $srcs 2> cppcheck.txt || true
+          cat cppcheck.txt
+          < cppcheck.txt reviewdog -efm='%f:%l:%c: %trror: %m' -efm='%f:%l:%c: %tarning: %m'             -efm='%f:%l: %trror: %m' -efm='%f:%l: %tarning: %m'             -name=cppcheck -reporter=github-pr-review -filter-mode=added             -fail-level=none -level=warning
+
+  clang-tidy:
+    name: clang-tidy (changed files)
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clang-tidy + build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy cmake build-essential pkg-config             libssl-dev libsodium-dev libsqlite3-dev libwebsockets-dev libpcap-dev
+      - name: Generate compile_commands.json (core + CLI only)
+        run: |
+          cmake -S . -B build-cq -DCMAKE_BUILD_TYPE=Release             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON             -DENABLE_GUI=OFF -DENABLE_TESTS=OFF
+      - name: Run clang-tidy
+        env:
+          FILES: ${{ needs.changes.outputs.files }}
+        run: |
+          : > tidy.txt
+          for f in $FILES; do
+            case "$f" in *.cpp|*.cc) ;; *) continue;; esac
+            grep -q "\"$f\"" build-cq/compile_commands.json ||               { echo "skip (not in compile DB): $f"; continue; }
+            echo "== clang-tidy $f"
+            clang-tidy -p build-cq --quiet "$f" >> tidy.txt 2>&1 || true
+          done
+          cat tidy.txt
+          < tidy.txt reviewdog -f=clang-tidy -name=clang-tidy             -reporter=github-pr-review -filter-mode=added             -fail-level=none -level=warning
+
+  lizard:
+    name: Complexity metrics (lizard)
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install lizard
+        run: pipx install lizard || pip install lizard
+      - name: Report complexity of changed files
+        env:
+          FILES: ${{ needs.changes.outputs.files }}
+        run: |
+          echo '## Cyclomatic complexity (changed files)' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          lizard -C 15 -L 100 -a 6 $FILES >> "$GITHUB_STEP_SUMMARY" 2>&1 || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          lizard -C 15 -L 100 -a 6 $FILES || true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+# GitHub-native static security analysis for C++ (security-and-quality suite).
+# Builds core + CLI only (GUI/Qt/tests skipped to keep the job fast).
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+  schedule:
+    - cron: '0 6 * * 1'   # weekly Monday 06:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze C++
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential pkg-config             libssl-dev libsodium-dev libsqlite3-dev libwebsockets-dev libpcap-dev
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          build-mode: manual
+          queries: security-and-quality
+
+      - name: Build core + CLI
+        run: |
+          cmake -S . -B build-codeql -DCMAKE_BUILD_TYPE=Release             -DENABLE_GUI=OFF -DENABLE_TESTS=OFF
+          cmake --build build-codeql -j$(nproc)
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:cpp'


### PR DESCRIPTION
## Что добавлено

Инкрементальный анализ качества кода в стиле **Designite Incremental Code Quality Analysis**, собранный из бесплатных инструментов — на PR флагаются **только изменённые строки/файлы**, старый код не трогается.

### `.github/workflows/code-quality.yml`
Триггер: PR и push в main/master/develop. Job `changes` определяет изменённые C++-файлы, дальше параллельно:

| Инструмент | Что ловит | Как репортит |
|---|---|---|
| **clang-format** (v18) | Стиль (4-space, attached braces, 100 cols) | Suggestions на изменённые строки (reviewdog `github-pr-review`, `filter-mode=added`) |
| **cppcheck** | warning/performance/portability | PR review-комментарии на изменённые строки |
| **clang-tidy** | bugprone/concurrency/misc/modernize/performance/portability/readability (умеренный профиль, compile DB из сборки core+CLI) | PR review-комментарии на изменённые строки |
| **lizard** | Цикломатическая сложность (CCN>15, >100 строк, >6 параметров) | Отчёт в GitHub Step Summary |

Все джобы **неблокирующие** (`fail_level: none`) — аннотации и ревью-комментарии, сборку не роняют. Для жёсткого гейта позже поднять `fail_level`.

### `.clang-format` / `.clang-tidy`
Конфиги под существующий стиль кода; шумные проверки отключены (magic-numbers, trailing-return-type, identifier-length и т.п.).

### `.github/workflows/codeql.yml`
CodeQL `security-and-quality` для C++: ручная сборка core+CLI (без GUI/Qt/тестов для скорости), триггеры — PR, push, еженедельно по понедельникам.

## Проверено
- YAML обоих workflows валиден (yaml.safe_load)
- `.clang-format` и `.clang-tidy` парсятся инструментами
- cppcheck прогнан на образце — чисто
- Конфиги совместимы со старыми версиями (clang-format 10+)