### PR TITLE
feat(spa): Ed25519 Single Packet Authorization module with ipset access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - ✅ **Phase 3: Anti-СОРМ** — CovertChannelManager (4 channels), CrossLayerCorrelator, GeoObfuscator
 - ✅ **Phase 4: Security** — PanicSequence (9 steps), Background Scheduler (8 tasks)
 
-- ✅ **Fully Implemented & Tested**: Cryptography, DPI Bypass (incl. midSLD splits, zapret chains, fake/fooling), DPI Advanced (multi-technique pipeline), Network Spoofing, Secure Memory/Buffer, DoH, Database, License, Logging, Configuration, CSPRNG, TLS Fingerprinting (JA3/JA4, browser profiles), Adversarial Padding, Flow Shaping, Probe Resistance, L2 Stealth, L3 Stealth, ARP Spoofing, DHCP Spoofing, Port Knocking, Packet Interceptor, Protocol Morphing, Burst Morphing, Entropy Masking, Geneva Engine/GA (crossover/mutation/selection, sync + background evolution), Identity Management, Timing Protection, Thread Pool, Rotation Coordinator, Security Manager, Capabilities Framework, I2P (SAM protocol client), Traffic Mimicry.
+- ✅ **Fully Implemented & Tested**: Cryptography, DPI Bypass (incl. midSLD splits, zapret chains, fake/fooling), DPI Advanced (multi-technique pipeline), Network Spoofing, Secure Memory/Buffer, DoH, Database, License, Logging, Configuration, CSPRNG, TLS Fingerprinting (JA3/JA4, browser profiles), Adversarial Padding, Flow Shaping, Probe Resistance, L2 Stealth, L3 Stealth, ARP Spoofing, DHCP Spoofing, Port Knocking, SPA (Ed25519 Single Packet Authorization + ipset gate control), Packet Interceptor, Protocol Morphing, Burst Morphing, Entropy Masking, Geneva Engine/GA (crossover/mutation/selection, sync + background evolution), Identity Management, Timing Protection, Thread Pool, Rotation Coordinator, Security Manager, Capabilities Framework, I2P (SAM protocol client), Traffic Mimicry.
 
 - ✅ **Security Fixes Applied**:
   - ECH info string mismatch — FIXED (canonical info string)
@@ -319,6 +319,38 @@ Exact + suffix domain matching (`*.example.com`, bare `example.com`,
 two-level TLD aware). Auto-hostlist records hosts where DPI blocking was
 detected (timeout / RST injection) and feeds them back into chain
 selection (`--hostlist` rules).
+
+### Single Packet Authorization — `ncp spa`
+
+Enterprise-grade SPA (upgrade over classic port knocking, which is vulnerable
+to replay and timing analysis): the protected service port stays a black hole
+for scanners until the client sends a **single Ed25519-signed UDP packet**
+(256 bytes: key-id, timestamp, nonce, requested proto/port/TTL + 64-byte
+signature + CSPRNG padding). The server verifies the signature against an
+authorized-keys file, rejects replays (per-key nonce cache + ±60 s timestamp
+window), and only then dynamically opens access — for that source IP only —
+via **ipset** with automatic TTL expiry:
+
+```bash
+ncp spa keygen --out client                        # Ed25519 keypair + authorized_keys line
+ncp spa serve --authorized-keys keys.txt \
+    --port 54117 --set-name ncp_spa_allow \
+    --default-ttl 300 --max-ttl 86400              # [--dry-run] to log without applying
+ncp spa knock <server-ip> --key client.key \
+    --allow-port 443 --ttl 300                     # open tcp/443 for this IP only
+```
+
+Server-side gate rule (printed by `serve` at startup):
+
+```bash
+iptables -A INPUT -p tcp --dport 443 -m set ! --match-set ncp_spa_allow src -j DROP
+```
+
+Verified in the Docker DPI Lab: pre-knock connections time out (DROP), a valid
+knock returns HTTP 200 through the gate, replayed packets are rejected
+(REPLAY), unknown keys are rejected (UNKNOWN_KEY), and access closes
+automatically on TTL expiry. Asymmetric design: the server stores only public
+keys, so a server compromise does not leak client signing capability.
 
 ### Passive DPI detector
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -28,6 +28,7 @@
 #include "ncp_hostlist.hpp"
 #include "ncp_dpi_detector.hpp"
 #include "ncp_autopilot.hpp"
+#include "ncp_spa.hpp"
 
 #include <iostream>
 #include <string>
@@ -819,6 +820,7 @@ void handle_blockcheck(const std::vector<std::string>& args);
 void handle_autopilot(const std::vector<std::string>& args);
 void handle_sysproxy(const std::vector<std::string>& args);
 void handle_import_zapret(const std::vector<std::string>& args);
+void handle_spa(const std::vector<std::string>& args);
 
 // ============================================================================
 // main()
@@ -845,6 +847,7 @@ int main(int argc, char* argv[]) {
     parser.add_command("autopilot", "Adaptive self-learning DPI bypass engine", handle_autopilot, {"<status|learn|reset|enable|disable|learn-preset>", "[domain|preset]", "[--json]", "[--timeout ms]"});
     parser.add_command("sysproxy", "System-wide proxy for applications (Discord etc.)", handle_sysproxy, {"<on|off|status>", "[--port N]"});
     parser.add_command("import-zapret", "Import zapret CLI strategy into NCP profile", handle_import_zapret, {"--args <zapret-args> | --file f", "[--out profile.json]"});
+    parser.add_command("spa", "Ed25519 Single Packet Authorization (keygen/knock/serve)", handle_spa, {"<keygen|knock|serve>", "[--out prefix]", "[--key f.key]", "[--allow-port N]", "[--port 54117]", "[--proto tcp]", "[--ttl S]", "[--authorized-keys f]", "[--set-name ncp_spa_allow]", "[--default-ttl 300]", "[--max-ttl 86400]", "[--dry-run]"});
 
     parser.parse_and_execute(argc, argv);
 
@@ -3407,4 +3410,153 @@ void handle_import_zapret(const std::vector<std::string>& args) {
     if (!result.warnings.empty())
         std::cout << ", " << result.warnings.size() << " warning(s)";
     std::cout << "\n";
+}
+
+// ============================================================================
+// ncp spa — Ed25519 Single Packet Authorization (keygen/knock/serve)
+// ============================================================================
+
+static void spa_print_usage() {
+    std::cout << "Usage: ncp spa <action> [options]\n"
+              << "  keygen --out <prefix>              Generate keypair -> <prefix>.key; prints key_id + authorized_keys line\n"
+              << "  knock <host> --key <file.key> --allow-port <N> [--port 54117] [--proto tcp] [--ttl S] [--send-twice]\n"
+              << "  serve --authorized-keys <file> [--port 54117] [--bind 0.0.0.0] [--set-name ncp_spa_allow]\n"
+              << "        [--default-ttl 300] [--max-ttl 86400] [--dry-run]\n";
+}
+
+void handle_spa(const std::vector<std::string>& args) {
+    if (args.empty() || has_flag(args, "--help") || has_flag(args, "-h")) {
+        spa_print_usage();
+        return;
+    }
+    const std::string action = args[0];
+
+    // ── keygen ──────────────────────────────────────────────────────────────
+    if (action == "keygen") {
+        const std::string prefix = get_option(args, "--out", "spa");
+        ncp::SpaClient client;
+        if (!client.generate()) {
+            std::cerr << "[!] SPA key generation failed\n";
+            return;
+        }
+        const std::string key_path = prefix + ".key";
+        if (!client.save_keyfile(key_path)) {
+            std::cerr << "[!] Cannot write " << key_path << "\n";
+            return;
+        }
+        std::cout << "[+] SPA keypair written to " << key_path << " (keep it secret)\n"
+                  << "    key_id: " << client.key_id_hex() << "\n"
+                  << "    authorized_keys line (add on the server):\n"
+                  << client.pubkey_base64() << "\n";
+        return;
+    }
+
+    // ── knock ───────────────────────────────────────────────────────────────
+    if (action == "knock") {
+        // first positional after the action is the target host
+        std::string host;
+        for (size_t i = 1; i < args.size(); ++i) {
+            if (args[i].rfind("--", 0) == 0) { ++i; continue; }  // skip option + value
+            if (args[i] == "--send-twice") continue;
+            host = args[i];
+            break;
+        }
+        const std::string key_path = get_option(args, "--key", "");
+        const int udp_port    = get_option_int(args, "--port", static_cast<int>(ncp::SPA_DEFAULT_PORT));
+        const int allow_port  = get_option_int(args, "--allow-port", 0);
+        const std::string ps  = get_option(args, "--proto", "tcp");
+        const int ttl         = get_option_int(args, "--ttl", 0);
+        const bool twice      = has_flag(args, "--send-twice");
+        const uint8_t proto   = (ps == "udp") ? 17 : 6;
+
+        if (host.empty() || key_path.empty() || allow_port <= 0 || allow_port > 65535) {
+            std::cerr << "[!] knock requires <host>, --key <file.key> and --allow-port <N>\n";
+            spa_print_usage();
+            return;
+        }
+
+        ncp::SpaClient client;
+        if (!client.load_keyfile(key_path)) {
+            std::cerr << "[!] Cannot load SPA key from " << key_path << "\n";
+            return;
+        }
+        auto pkt = client.build_packet(proto, static_cast<uint16_t>(allow_port),
+                                       static_cast<uint32_t>(ttl));
+        if (pkt.empty()) {
+            std::cerr << "[!] Failed to build SPA packet\n";
+            return;
+        }
+        if (!client.send_packet(host, static_cast<uint16_t>(udp_port), pkt)) {
+            std::cerr << "[!] Knock send failed to " << host << ":" << udp_port << "\n";
+            return;
+        }
+        std::cout << "[+] SPA knock sent to " << host << ":" << udp_port
+                  << " (open " << ps << "/" << allow_port
+                  << ", key_id " << client.key_id_hex() << ")\n";
+        if (twice) {
+            // Replay self-test: resend the exact same datagram — the server
+            // must answer REPLAY (no second grant).
+            std::this_thread::sleep_for(std::chrono::milliseconds(300));
+            client.send_packet(host, static_cast<uint16_t>(udp_port), pkt);
+            std::cout << "[+] Same packet re-sent (expect REPLAY on the server)\n";
+        }
+        return;
+    }
+
+    // ── serve ───────────────────────────────────────────────────────────────
+    if (action == "serve") {
+        const std::string keys_path = get_option(args, "--authorized-keys", "");
+        if (keys_path.empty()) {
+            std::cerr << "[!] serve requires --authorized-keys <file>\n";
+            spa_print_usage();
+            return;
+        }
+        const int port        = get_option_int(args, "--port", static_cast<int>(ncp::SPA_DEFAULT_PORT));
+        const std::string bind_addr  = get_option(args, "--bind", "0.0.0.0");
+        const std::string set_name   = get_option(args, "--set-name", "ncp_spa_allow");
+        const int default_ttl = get_option_int(args, "--default-ttl", 300);
+        const int max_ttl     = get_option_int(args, "--max-ttl", 86400);
+        const bool dry_run    = has_flag(args, "--dry-run");
+
+        ncp::SpaServer::Config cfg;
+        cfg.default_ttl_sec = static_cast<uint32_t>(default_ttl);
+        cfg.max_ttl_sec     = static_cast<uint32_t>(max_ttl);
+
+        auto ctrl = std::make_shared<ncp::IpSetAccessController>(set_name, dry_run);
+        ncp::SpaServer server(cfg);
+        server.set_access_controller(ctrl);
+        if (!server.load_authorized_keys(keys_path)) {
+            std::cerr << "[!] No valid keys loaded from " << keys_path << "\n";
+            return;
+        }
+        ctrl->ensure_set();
+
+        std::cout << "═══ NCP SPA server ═══\n"
+                  << "  Listen:          UDP " << bind_addr << ":" << port << "\n"
+                  << "  Authorized keys: " << server.authorized_key_count()
+                  << " (" << keys_path << ")\n"
+                  << "  ipset:           " << set_name
+                  << (dry_run ? " (DRY-RUN — commands logged only)" : "") << "\n"
+                  << "  TTL:             default " << default_ttl << "s, max " << max_ttl << "s\n"
+                  << "  Companion firewall rule (per protected port):\n"
+                  << "    " << ncp::IpSetAccessController::iptables_rule_hint(6, 22, set_name) << "\n";
+
+        ncp::SpaDaemon daemon(server, static_cast<uint16_t>(port), bind_addr);
+        if (!daemon.start()) {
+            std::cerr << "[!] Failed to start SPA daemon on UDP " << bind_addr << ":" << port << "\n";
+            return;
+        }
+        std::cout << "[*] SPA daemon running — Ctrl-C to stop\n";
+
+        g_running = 1;
+        while (g_running) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+        daemon.stop();
+        std::cout << "[*] SPA daemon stopped\n";
+        return;
+    }
+
+    std::cerr << "[!] Unknown spa action: " << action << "\n";
+    spa_print_usage();
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -56,6 +56,7 @@ set(NCP_CORE_SRC_SOURCES
     src/ncp_probe_resist.cpp     # Phase 3: active probing resistance
     src/ncp_orchestrator.cpp     # Phase 4: unified pipeline orchestrator
     src/ncp_port_knock.cpp       # Phase 5: port knocking (TOTP/SPA/covert)
+    src/ncp_spa.cpp              # Enterprise SPA (Ed25519 + ipset)
     # L3/L2 Stealth modules (Anti-ISP fingerprinting)
     src/ncp_l3_stealth.cpp       # Phase 1: IPID/TTL/MSS/FlowLabel normalization
     src/ncp_packet_interceptor.cpp # Phase 2: NFQUEUE/WinDivert packet interception + tunneling
@@ -107,6 +108,7 @@ set(NCP_CORE_SRC_SOURCES
     include/ncp_probe_resist.hpp
     include/ncp_orchestrator.hpp
     include/ncp_port_knock.hpp
+    include/ncp_spa.hpp
     # New Anti-TSPU headers
     include/ncp_packet_pipeline.hpp
     include/ncp_dns_leak_prevention.hpp

--- a/src/core/include/ncp_spa.hpp
+++ b/src/core/include/ncp_spa.hpp
@@ -1,0 +1,280 @@
+#pragma once
+
+/**
+ * @file ncp_spa.hpp
+ * @brief Enterprise Single Packet Authorization (SPA) — Ed25519 + ipset
+ *
+ * Replaces/extends the symmetric-HMAC SPA inside PortKnock with an
+ * asymmetric scheme:
+ *   - Client signs a fixed 256-byte UDP packet with its Ed25519 secret key.
+ *   - Server only stores public keys (authorized_keys file), so a server
+ *     compromise does not reveal any client secret material.
+ *   - key_id = first 8 bytes of BLAKE2b-64(pubkey) — packets carry no
+ *     identity beyond an opaque key fingerprint.
+ *   - Replay protection: per-key nonce cache (16-byte CSPRNG nonces,
+ *     entries expire after 120 s) plus a +/-60 s timestamp window.
+ *   - On success the source IP is added to an ipset with a TTL; the
+ *     protected TCP/UDP services stay fully DROP otherwise.
+ *
+ * Wire format (UDP payload, fixed 256 bytes, all integers big-endian):
+ *   offset  size  field
+ *   0       2     magic "SP" (0x53 0x50)
+ *   2       1     version = 1
+ *   3       8     key_id = BLAKE2b-64 of client Ed25519 pubkey
+ *   11      8     timestamp_unix (seconds)
+ *   19      16    nonce (CSPRNG)
+ *   35      1     protocol (6=TCP, 17=UDP)
+ *   36      2     allow_port — port the client wants opened
+ *   38      4     requested_ttl_sec (0 = server default)
+ *   42      64    Ed25519 signature over bytes [0..42)
+ *   106     150   random padding (CSPRNG)
+ *
+ * Capture rationale (v1): SpaDaemon binds a plain UDP socket on the SPA
+ * listen port. UDP has no connection state, so binding the port does not
+ * expose any handshake surface for the protected TCP services — those stay
+ * fully DROP. The SPA port itself answers nothing (never sends replies),
+ * so a scanner only sees an open/closed UDP port that never responds.
+ * NFQUEUE-based fully-stealth capture (no bound socket at all) is a
+ * documented follow-up.
+ */
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "ncp_crypto.hpp"
+#include "ncp_secure_memory.hpp"
+
+namespace ncp {
+
+// ===== Wire format constants =====
+
+constexpr size_t   SPA_PACKET_SIZE        = 256;
+constexpr size_t   SPA_SIGNED_LEN         = 42;   // bytes covered by the signature
+constexpr uint8_t  SPA_VERSION            = 1;
+constexpr size_t   SPA_KEY_ID_LEN         = 8;
+constexpr size_t   SPA_NONCE_LEN          = 16;
+constexpr size_t   SPA_SIGNATURE_OFFSET   = 42;
+constexpr size_t   SPA_PADDING_OFFSET     = 106;
+constexpr uint16_t SPA_DEFAULT_PORT       = 54117;
+
+using SpaKeyId = std::array<uint8_t, SPA_KEY_ID_LEN>;
+
+// ===== Server decision result =====
+
+enum class SpaResult {
+    GRANTED,          // signature valid, access granted
+    BAD_FORMAT,       // size/magic/version mismatch
+    UNKNOWN_KEY,      // key_id not in authorized_keys
+    STALE_TIMESTAMP,  // |now - ts| > window
+    REPLAY,           // nonce already seen for this key
+    BAD_SIGNATURE     // Ed25519 verification failed
+};
+
+const char* spa_result_to_string(SpaResult r) noexcept;
+
+// ===== Access controller interface =====
+
+struct IAccessController {
+    virtual ~IAccessController() = default;
+    virtual bool grant(const std::string& src_ip, uint8_t proto,
+                       uint16_t port, uint32_t ttl_sec) = 0;
+};
+
+/**
+ * @brief ipset-backed access controller.
+ *
+ * Ensures `ipset create <set> hash:ip timeout 0 -exist`, then on grant:
+ *   `ipset add <set> <src_ip> timeout <ttl> -exist`
+ * Commands are executed via an injectable command runner (default ::system,
+ * consistent with ncp_dns_leak_prevention.cpp). In dry_run mode commands
+ * are only logged/recorded, never executed. Every command is logged.
+ */
+class IpSetAccessController : public IAccessController {
+public:
+    using CommandRunner = std::function<int(const std::string& cmd)>;
+
+    IpSetAccessController(std::string set_name, bool dry_run);
+
+    bool grant(const std::string& src_ip, uint8_t proto,
+               uint16_t port, uint32_t ttl_sec) override;
+
+    /// Create the ipset if missing (idempotent). Called lazily on first grant.
+    bool ensure_set();
+
+    /// Documented companion iptables rule for README/logging.
+    static std::string iptables_rule_hint(uint8_t proto, uint16_t port,
+                                          const std::string& set_name);
+
+    /// Test hook: replace the command executor.
+    void set_command_runner(CommandRunner runner);
+
+    /// Test hook: last ipset command issued (empty if none).
+    std::string last_command() const;
+
+    const std::string& set_name() const noexcept { return set_name_; }
+    bool dry_run() const noexcept { return dry_run_; }
+
+private:
+    int run_command(const std::string& cmd);
+
+    std::string set_name_;
+    bool dry_run_;
+    bool set_ensured_ = false;
+    CommandRunner runner_;
+    mutable std::mutex mu_;
+    std::string last_command_;
+};
+
+// ===== SPA server =====
+
+class SpaServer {
+public:
+    struct Config {
+        uint32_t default_ttl_sec      = 300;    // used when packet ttl == 0
+        uint32_t max_ttl_sec          = 86400;  // hard clamp
+        uint64_t timestamp_window_sec = 60;     // +/- window
+        uint64_t nonce_ttl_sec        = 120;    // replay-cache entry lifetime
+    };
+
+    SpaServer();
+    explicit SpaServer(Config cfg);
+
+    void set_access_controller(std::shared_ptr<IAccessController> ctrl);
+
+    /// Load authorized_keys: one base64 Ed25519 pubkey (32 raw bytes) per
+    /// line; '#' comments and blank lines allowed. Returns false if the file
+    /// cannot be opened or contains no valid keys.
+    bool load_authorized_keys(const std::string& path);
+
+    /// Add a single raw 32-byte Ed25519 pubkey (test/embedding helper).
+    bool add_authorized_key(const uint8_t* pubkey, size_t len);
+
+    size_t authorized_key_count() const;
+
+    /// Full verification pipeline; never throws.
+    SpaResult process_packet(const uint8_t* data, size_t len,
+                             const std::string& src_ip) noexcept;
+    SpaResult process_packet(const std::vector<uint8_t>& data,
+                             const std::string& src_ip) noexcept {
+        return process_packet(data.data(), data.size(), src_ip);
+    }
+
+    /// Compute key_id for a raw 32-byte pubkey.
+    static SpaKeyId key_id_for(const uint8_t* pubkey, size_t len);
+
+private:
+    void sweep_replay_cache_locked(std::chrono::steady_clock::time_point now);
+
+    Config cfg_;
+    Crypto crypto_;
+    std::shared_ptr<IAccessController> controller_;
+
+    mutable std::shared_mutex keys_mu_;
+    std::unordered_map<std::string, std::array<uint8_t, 32>> keys_;  // key_id -> pubkey
+
+    mutable std::mutex replay_mu_;
+    // key_id -> (nonce -> first-seen time)
+    std::unordered_map<std::string,
+        std::unordered_map<std::string, std::chrono::steady_clock::time_point>> replay_cache_;
+};
+
+// ===== SPA client =====
+
+/**
+ * @brief Holds an Ed25519 keypair and builds/knocks SPA packets.
+ *
+ * Key file format (created by `ncp spa keygen`): a single base64 line of
+ * the 96-byte blob [64-byte libsodium secret key || 32-byte pubkey].
+ */
+class SpaClient {
+public:
+    SpaClient();
+
+    /// Generate a fresh keypair (invalidates any previously loaded one).
+    bool generate();
+
+    bool load_keyfile(const std::string& path);
+    bool save_keyfile(const std::string& path) const;
+
+    bool has_key() const noexcept;
+
+    /// Build a 256-byte packet per the wire format (timestamp = now).
+    std::vector<uint8_t> build_packet(uint8_t proto, uint16_t allow_port,
+                                      uint32_t ttl_sec) const;
+
+    /// Same as build_packet but with an explicit unix timestamp
+    /// (testing / clock-skew scenarios).
+    std::vector<uint8_t> build_packet_ts(uint8_t proto, uint16_t allow_port,
+                                         uint32_t ttl_sec,
+                                         uint64_t timestamp_unix) const;
+
+    /// Send a single UDP datagram to host:udp_port. Returns true if sent.
+    bool knock(const std::string& host, uint16_t udp_port, uint8_t proto,
+               uint16_t allow_port, uint32_t ttl_sec) const;
+
+    /// Send an already-built packet verbatim (replay self-test helper).
+    bool send_packet(const std::string& host, uint16_t udp_port,
+                     const std::vector<uint8_t>& packet) const;
+
+    SpaKeyId key_id() const;
+    std::string key_id_hex() const;
+
+    /// base64 of the raw 32-byte pubkey — the authorized_keys line.
+    std::string pubkey_base64() const;
+
+private:
+    SecureMemory secret_key_;  // 64 bytes (libsodium format)
+    SecureMemory public_key_;  // 32 bytes
+    mutable Crypto crypto_;
+};
+
+// ===== SPA daemon (UDP capture, v1) =====
+
+/**
+ * @brief Binds a UDP socket and feeds datagrams to SpaServer.
+ *
+ * Loop: recvfrom with SO_RCVTIMEO 1 s, check stop flag, dispatch. The
+ * daemon never sends replies. See file header for the capture rationale.
+ */
+class SpaDaemon {
+public:
+    SpaDaemon(SpaServer& server, uint16_t port,
+              std::string bind_addr = "0.0.0.0");
+    ~SpaDaemon();
+
+    SpaDaemon(const SpaDaemon&) = delete;
+    SpaDaemon& operator=(const SpaDaemon&) = delete;
+
+    /// Bind + spawn the receive thread. False on bind failure.
+    bool start();
+    void stop();
+    bool running() const noexcept { return running_.load(); }
+
+private:
+    void loop();
+
+    SpaServer& server_;
+    uint16_t port_;
+    std::string bind_addr_;
+    int sock_ = -1;
+    std::atomic<bool> stop_flag_{false};
+    std::atomic<bool> running_{false};
+    std::thread thread_;
+};
+
+// ===== base64 helpers (VARIANT_ORIGINAL, no padding surprises) =====
+
+std::string spa_base64_encode(const uint8_t* data, size_t len);
+bool spa_base64_decode(const std::string& b64, std::vector<uint8_t>& out);
+
+} // namespace ncp

--- a/src/core/src/ncp_spa.cpp
+++ b/src/core/src/ncp_spa.cpp
@@ -1,0 +1,581 @@
+/**
+ * @file ncp_spa.cpp
+ * @brief Enterprise Single Packet Authorization (SPA) — implementation
+ *
+ * See ncp_spa.hpp for the wire format and design notes.
+ */
+
+#include "ncp_spa.hpp"
+#include "ncp_csprng.hpp"
+#include "ncp_logger.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+
+#include <sodium.h>
+
+#ifndef _WIN32
+#  include <arpa/inet.h>
+#  include <netdb.h>
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#  include <sys/types.h>
+#  include <unistd.h>
+#else
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#endif
+
+namespace ncp {
+
+// ============================================================================
+// base64 helpers
+// ============================================================================
+
+std::string spa_base64_encode(const uint8_t* data, size_t len) {
+    if (!data || len == 0) return "";
+    const size_t b64_len = sodium_base64_encoded_len(len, sodium_base64_VARIANT_ORIGINAL);
+    std::string out(b64_len, '\0');
+    sodium_bin2base64(out.data(), out.size(), data, len, sodium_base64_VARIANT_ORIGINAL);
+    out.resize(std::strlen(out.c_str()));
+    return out;
+}
+
+bool spa_base64_decode(const std::string& b64, std::vector<uint8_t>& out) {
+    out.clear();
+    if (b64.empty()) return false;
+    out.resize(b64.size());  // upper bound
+    size_t bin_len = 0;
+    if (sodium_base642bin(out.data(), out.size(),
+                          b64.c_str(), b64.size(),
+                          nullptr, &bin_len, nullptr,
+                          sodium_base64_VARIANT_ORIGINAL) != 0) {
+        out.clear();
+        return false;
+    }
+    out.resize(bin_len);
+    return true;
+}
+
+// ============================================================================
+// SpaResult
+// ============================================================================
+
+const char* spa_result_to_string(SpaResult r) noexcept {
+    switch (r) {
+        case SpaResult::GRANTED:         return "GRANTED";
+        case SpaResult::BAD_FORMAT:      return "BAD_FORMAT";
+        case SpaResult::UNKNOWN_KEY:     return "UNKNOWN_KEY";
+        case SpaResult::STALE_TIMESTAMP: return "STALE_TIMESTAMP";
+        case SpaResult::REPLAY:          return "REPLAY";
+        case SpaResult::BAD_SIGNATURE:   return "BAD_SIGNATURE";
+    }
+    return "UNKNOWN";
+}
+
+// ============================================================================
+// IpSetAccessController
+// ============================================================================
+
+IpSetAccessController::IpSetAccessController(std::string set_name, bool dry_run)
+    : set_name_(std::move(set_name)), dry_run_(dry_run) {}
+
+std::string IpSetAccessController::iptables_rule_hint(uint8_t proto, uint16_t port,
+                                                      const std::string& set_name) {
+    std::ostringstream oss;
+    oss << "iptables -A INPUT -p "
+        << (proto == 17 ? "udp" : "tcp")
+        << " --dport " << port
+        << " -m set ! --match-set " << set_name << " src -j DROP";
+    return oss.str();
+}
+
+void IpSetAccessController::set_command_runner(CommandRunner runner) {
+    std::lock_guard<std::mutex> lk(mu_);
+    runner_ = std::move(runner);
+}
+
+std::string IpSetAccessController::last_command() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return last_command_;
+}
+
+int IpSetAccessController::run_command(const std::string& cmd) {
+    CommandRunner runner;
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        last_command_ = cmd;
+        runner = runner_;
+    }
+    NCP_LOG_INFO(std::string("[SPA] ipset: ") + cmd +
+                 (dry_run_ ? " (dry-run, not executed)" : ""));
+    if (dry_run_) return 0;
+    if (runner) return runner(cmd);
+    NCP_LOG_DEBUG(std::string("[SPA] system(\"") + cmd + "\")");
+    return ::system(cmd.c_str());
+}
+
+bool IpSetAccessController::ensure_set() {
+    if (set_ensured_) return true;
+    const std::string cmd = "ipset create " + set_name_ + " hash:ip timeout 0 -exist";
+    if (run_command(cmd) == 0) {
+        set_ensured_ = true;
+        return true;
+    }
+    NCP_LOG_ERROR(std::string("[SPA] failed to create ipset '") + set_name_ + "'");
+    return false;
+}
+
+bool IpSetAccessController::grant(const std::string& src_ip, uint8_t proto,
+                                  uint16_t port, uint32_t ttl_sec) {
+    (void)proto;  // ipset hash:ip is protocol-agnostic; proto is for logging/rules
+    (void)port;
+    if (!ensure_set()) return false;
+    const std::string cmd = "ipset add " + set_name_ + " " + src_ip +
+                            " timeout " + std::to_string(ttl_sec) + " -exist";
+    if (run_command(cmd) != 0) {
+        NCP_LOG_ERROR(std::string("[SPA] ipset add failed for ") + src_ip);
+        return false;
+    }
+    NCP_LOG_INFO(std::string("[SPA] granted ") + src_ip + " ttl=" +
+                 std::to_string(ttl_sec) + "s");
+    return true;
+}
+
+// ============================================================================
+// SpaServer
+// ============================================================================
+
+SpaServer::SpaServer() = default;
+
+SpaServer::SpaServer(Config cfg) : cfg_(cfg) {}
+
+void SpaServer::set_access_controller(std::shared_ptr<IAccessController> ctrl) {
+    controller_ = std::move(ctrl);
+}
+
+SpaKeyId SpaServer::key_id_for(const uint8_t* pubkey, size_t len) {
+    SpaKeyId id{};
+    if (!pubkey || len != 32) return id;
+    // BLAKE2b-64 (8-byte output) — Crypto::hash_blake2b enforces
+    // crypto_generichash_BYTES_MIN (16), so call libsodium directly.
+    crypto_generichash(id.data(), id.size(), pubkey, len, nullptr, 0);
+    return id;
+}
+
+bool SpaServer::add_authorized_key(const uint8_t* pubkey, size_t len) {
+    if (!pubkey || len != 32) return false;
+    SpaKeyId id = key_id_for(pubkey, len);
+    std::array<uint8_t, 32> pk{};
+    std::memcpy(pk.data(), pubkey, 32);
+    std::string id_str(reinterpret_cast<const char*>(id.data()), id.size());
+    {
+        std::unique_lock<std::shared_mutex> lk(keys_mu_);
+        keys_[id_str] = pk;
+    }
+    NCP_LOG_INFO(std::string("[SPA] authorized key added, key_id=") +
+                 Crypto::bytes_to_hex(SecureMemory(id.data(), id.size())));
+    return true;
+}
+
+bool SpaServer::load_authorized_keys(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        NCP_LOG_ERROR(std::string("[SPA] cannot open authorized_keys: ") + path);
+        return false;
+    }
+    size_t added = 0;
+    std::string line;
+    while (std::getline(f, line)) {
+        const size_t b = line.find_first_not_of(" \t\r\n");
+        if (b == std::string::npos) continue;             // blank
+        if (line[b] == '#') continue;                     // comment
+        const size_t e = line.find_last_not_of(" \t\r\n");
+        std::vector<uint8_t> pk;
+        if (!spa_base64_decode(line.substr(b, e - b + 1), pk) || pk.size() != 32) {
+            NCP_LOG_WARN(std::string("[SPA] skipping invalid authorized_keys line: ") +
+                         line.substr(b, e - b + 1));
+            continue;
+        }
+        if (add_authorized_key(pk.data(), pk.size())) ++added;
+    }
+    NCP_LOG_INFO(std::string("[SPA] loaded ") + std::to_string(added) +
+                 " authorized key(s) from " + path);
+    return added > 0;
+}
+
+size_t SpaServer::authorized_key_count() const {
+    std::shared_lock<std::shared_mutex> lk(keys_mu_);
+    return keys_.size();
+}
+
+void SpaServer::sweep_replay_cache_locked(std::chrono::steady_clock::time_point now) {
+    const auto ttl = std::chrono::seconds(cfg_.nonce_ttl_sec);
+    for (auto it = replay_cache_.begin(); it != replay_cache_.end();) {
+        auto& nonces = it->second;
+        for (auto n = nonces.begin(); n != nonces.end();) {
+            if (now - n->second > ttl) n = nonces.erase(n);
+            else ++n;
+        }
+        if (nonces.empty()) it = replay_cache_.erase(it);
+        else ++it;
+    }
+}
+
+SpaResult SpaServer::process_packet(const uint8_t* data, size_t len,
+                                    const std::string& src_ip) noexcept {
+    auto log_decision = [&](SpaResult r) {
+        NCP_LOG_INFO(std::string("[SPA] ") + spa_result_to_string(r) +
+                     " src=" + src_ip);
+    };
+
+    // 1. size / magic / version
+    if (!data || len != SPA_PACKET_SIZE ||
+        data[0] != 'S' || data[1] != 'P' || data[2] != SPA_VERSION) {
+        log_decision(SpaResult::BAD_FORMAT);
+        return SpaResult::BAD_FORMAT;
+    }
+
+    // 2. key_id known?
+    const std::string key_id(reinterpret_cast<const char*>(data + 3), SPA_KEY_ID_LEN);
+    std::array<uint8_t, 32> pubkey{};
+    {
+        std::shared_lock<std::shared_mutex> lk(keys_mu_);
+        auto it = keys_.find(key_id);
+        if (it == keys_.end()) {
+            log_decision(SpaResult::UNKNOWN_KEY);
+            return SpaResult::UNKNOWN_KEY;
+        }
+        pubkey = it->second;
+    }
+
+    // 3. timestamp window
+    uint64_t ts = 0;
+    for (size_t i = 0; i < 8; ++i) ts = (ts << 8) | data[11 + i];
+    const uint64_t now_s = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    const uint64_t diff = (now_s > ts) ? (now_s - ts) : (ts - now_s);
+    if (diff > cfg_.timestamp_window_sec) {
+        log_decision(SpaResult::STALE_TIMESTAMP);
+        return SpaResult::STALE_TIMESTAMP;
+    }
+
+    // 4. nonce replay check
+    const std::string nonce(reinterpret_cast<const char*>(data + 19), SPA_NONCE_LEN);
+    {
+        std::lock_guard<std::mutex> lk(replay_mu_);
+        sweep_replay_cache_locked(std::chrono::steady_clock::now());
+        auto kit = replay_cache_.find(key_id);
+        if (kit != replay_cache_.end() && kit->second.count(nonce) != 0) {
+            log_decision(SpaResult::REPLAY);
+            return SpaResult::REPLAY;
+        }
+    }
+
+    // 5. Ed25519 verify over bytes [0..42)
+    SecureMemory msg(data, SPA_SIGNED_LEN);
+    SecureMemory sig(data + SPA_SIGNATURE_OFFSET, 64);
+    SecureMemory pk(pubkey.data(), pubkey.size());
+    if (!crypto_.verify_ed25519(msg, sig, pk)) {
+        log_decision(SpaResult::BAD_SIGNATURE);
+        return SpaResult::BAD_SIGNATURE;
+    }
+
+    // 6. success — record nonce, grant access
+    const uint8_t  proto = data[35];
+    const uint16_t port  = static_cast<uint16_t>((data[36] << 8) | data[37]);
+    uint32_t ttl = 0;
+    for (size_t i = 0; i < 4; ++i) ttl = (ttl << 8) | data[38 + i];
+    if (ttl == 0) ttl = cfg_.default_ttl_sec;
+    ttl = (std::min)(ttl, cfg_.max_ttl_sec);
+
+    {
+        std::lock_guard<std::mutex> lk(replay_mu_);
+        replay_cache_[key_id][nonce] = std::chrono::steady_clock::now();
+    }
+
+    if (controller_) {
+        if (!controller_->grant(src_ip, proto, port, ttl)) {
+            NCP_LOG_ERROR(std::string("[SPA] access controller failed for ") + src_ip);
+        }
+    } else {
+        NCP_LOG_WARN("[SPA] no access controller configured — packet valid but no grant issued");
+    }
+
+    NCP_LOG_INFO(std::string("[SPA] GRANTED src=") + src_ip +
+                 " proto=" + std::to_string(proto) +
+                 " port=" + std::to_string(port) +
+                 " ttl=" + std::to_string(ttl) + "s");
+    return SpaResult::GRANTED;
+}
+
+// ============================================================================
+// SpaClient
+// ============================================================================
+
+SpaClient::SpaClient() = default;
+
+bool SpaClient::has_key() const noexcept {
+    return secret_key_.size() == 64 && public_key_.size() == 32;
+}
+
+bool SpaClient::generate() {
+    Crypto crypto;
+    auto kp = crypto.generate_keypair();
+    if (!kp.is_valid() || kp.secret_key.size() != 64 || kp.public_key.size() != 32) {
+        return false;
+    }
+    secret_key_ = SecureMemory(kp.secret_key.data(), kp.secret_key.size());
+    public_key_ = SecureMemory(kp.public_key.data(), kp.public_key.size());
+    return true;
+}
+
+bool SpaClient::load_keyfile(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        NCP_LOG_ERROR(std::string("[SPA] cannot open key file: ") + path);
+        return false;
+    }
+    std::string line;
+    std::getline(f, line);
+    const size_t b = line.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) return false;
+    const size_t e = line.find_last_not_of(" \t\r\n");
+
+    std::vector<uint8_t> blob;
+    if (!spa_base64_decode(line.substr(b, e - b + 1), blob) || blob.size() != 96) {
+        NCP_LOG_ERROR(std::string("[SPA] invalid key file format: ") + path);
+        return false;
+    }
+    secret_key_ = SecureMemory(blob.data(), 64);
+    // Derive the pubkey from the secret key; fall back to the stored half.
+    std::array<uint8_t, 32> derived{};
+    if (crypto_sign_ed25519_sk_to_pk(derived.data(), secret_key_.data()) == 0 &&
+        std::memcmp(derived.data(), blob.data() + 64, 32) == 0) {
+        public_key_ = SecureMemory(blob.data() + 64, 32);
+    } else {
+        NCP_LOG_ERROR(std::string("[SPA] key file pubkey mismatch: ") + path);
+        secret_key_ = SecureMemory{};
+        return false;
+    }
+    SecureMemory::secure_zero(blob.data(), blob.size());
+    return true;
+}
+
+bool SpaClient::save_keyfile(const std::string& path) const {
+    if (!has_key()) return false;
+    std::vector<uint8_t> blob(96);
+    std::memcpy(blob.data(), secret_key_.data(), 64);
+    std::memcpy(blob.data() + 64, public_key_.data(), 32);
+    const std::string b64 = spa_base64_encode(blob.data(), blob.size());
+    SecureMemory::secure_zero(blob.data(), blob.size());
+
+    std::ofstream f(path, std::ios::trunc);
+    if (!f.is_open()) {
+        NCP_LOG_ERROR(std::string("[SPA] cannot write key file: ") + path);
+        return false;
+    }
+    f << b64 << "\n";
+    return static_cast<bool>(f);
+}
+
+std::vector<uint8_t> SpaClient::build_packet(uint8_t proto, uint16_t allow_port,
+                                             uint32_t ttl_sec) const {
+    const uint64_t now_s = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    return build_packet_ts(proto, allow_port, ttl_sec, now_s);
+}
+
+std::vector<uint8_t> SpaClient::build_packet_ts(uint8_t proto, uint16_t allow_port,
+                                                uint32_t ttl_sec,
+                                                uint64_t timestamp_unix) const {
+    std::vector<uint8_t> pkt;
+    if (!has_key()) return pkt;
+    pkt.assign(SPA_PACKET_SIZE, 0);
+
+    pkt[0] = 'S';
+    pkt[1] = 'P';
+    pkt[2] = SPA_VERSION;
+
+    const SpaKeyId id = key_id();
+    std::memcpy(pkt.data() + 3, id.data(), SPA_KEY_ID_LEN);
+
+    for (size_t i = 0; i < 8; ++i)
+        pkt[11 + i] = static_cast<uint8_t>((timestamp_unix >> (56 - i * 8)) & 0xFF);
+
+    csprng_fill(pkt.data() + 19, SPA_NONCE_LEN);
+
+    pkt[35] = proto;
+    pkt[36] = static_cast<uint8_t>((allow_port >> 8) & 0xFF);
+    pkt[37] = static_cast<uint8_t>(allow_port & 0xFF);
+    for (size_t i = 0; i < 4; ++i)
+        pkt[38 + i] = static_cast<uint8_t>((ttl_sec >> (24 - i * 8)) & 0xFF);
+
+    SecureMemory msg(pkt.data(), SPA_SIGNED_LEN);
+    SecureMemory sig = crypto_.sign_ed25519(msg, secret_key_);
+    if (sig.size() != 64) {
+        pkt.clear();
+        return pkt;
+    }
+    std::memcpy(pkt.data() + SPA_SIGNATURE_OFFSET, sig.data(), 64);
+
+    csprng_fill(pkt.data() + SPA_PADDING_OFFSET, SPA_PACKET_SIZE - SPA_PADDING_OFFSET);
+    return pkt;
+}
+
+SpaKeyId SpaClient::key_id() const {
+    if (public_key_.size() != 32) return SpaKeyId{};
+    return SpaServer::key_id_for(public_key_.data(), public_key_.size());
+}
+
+std::string SpaClient::key_id_hex() const {
+    const SpaKeyId id = key_id();
+    return Crypto::bytes_to_hex(SecureMemory(id.data(), id.size()));
+}
+
+std::string SpaClient::pubkey_base64() const {
+    if (public_key_.size() != 32) return "";
+    return spa_base64_encode(public_key_.data(), public_key_.size());
+}
+
+bool SpaClient::knock(const std::string& host, uint16_t udp_port, uint8_t proto,
+                      uint16_t allow_port, uint32_t ttl_sec) const {
+    const std::vector<uint8_t> pkt = build_packet(proto, allow_port, ttl_sec);
+    return send_packet(host, udp_port, pkt);
+}
+
+bool SpaClient::send_packet(const std::string& host, uint16_t udp_port,
+                            const std::vector<uint8_t>& packet) const {
+    const std::vector<uint8_t>& pkt = packet;
+    if (pkt.size() != SPA_PACKET_SIZE) return false;
+
+#ifdef _WIN32
+    NCP_LOG_ERROR("[SPA] knock is not supported on Windows yet");
+    (void)host; (void)udp_port;
+    return false;
+#else
+    struct addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    struct addrinfo* res = nullptr;
+    const std::string port_str = std::to_string(udp_port);
+    if (getaddrinfo(host.c_str(), port_str.c_str(), &hints, &res) != 0 || !res) {
+        NCP_LOG_ERROR(std::string("[SPA] cannot resolve ") + host);
+        return false;
+    }
+    bool sent = false;
+    for (struct addrinfo* ai = res; ai && !sent; ai = ai->ai_next) {
+        int s = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (s < 0) continue;
+        const ssize_t n = ::sendto(s, pkt.data(), pkt.size(), 0,
+                                   ai->ai_addr, ai->ai_addrlen);
+        ::close(s);
+        sent = (n == static_cast<ssize_t>(pkt.size()));
+    }
+    freeaddrinfo(res);
+    if (!sent) {
+        NCP_LOG_ERROR(std::string("[SPA] knock send failed to ") + host);
+    }
+    return sent;
+#endif
+}
+
+// ============================================================================
+// SpaDaemon
+// ============================================================================
+
+SpaDaemon::SpaDaemon(SpaServer& server, uint16_t port, std::string bind_addr)
+    : server_(server), port_(port), bind_addr_(std::move(bind_addr)) {}
+
+SpaDaemon::~SpaDaemon() {
+    stop();
+}
+
+bool SpaDaemon::start() {
+#ifdef _WIN32
+    NCP_LOG_ERROR("[SPA] SpaDaemon is not supported on Windows yet");
+    return false;
+#else
+    if (running_.load()) return true;
+
+    sock_ = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock_ < 0) {
+        NCP_LOG_ERROR(std::string("[SPA] socket() failed: ") + std::strerror(errno));
+        return false;
+    }
+
+    int one = 1;
+    ::setsockopt(sock_, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    struct timeval tv{};
+    tv.tv_sec = 1;  // SO_RCVTIMEO — 1 s loop so stop() is responsive
+    tv.tv_usec = 0;
+    ::setsockopt(sock_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    struct sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port_);
+    if (::inet_pton(AF_INET, bind_addr_.c_str(), &addr.sin_addr) != 1) {
+        NCP_LOG_ERROR(std::string("[SPA] invalid bind address: ") + bind_addr_);
+        ::close(sock_);
+        sock_ = -1;
+        return false;
+    }
+    if (::bind(sock_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+        NCP_LOG_ERROR(std::string("[SPA] bind ") + bind_addr_ + ":" +
+                      std::to_string(port_) + " failed: " + std::strerror(errno));
+        ::close(sock_);
+        sock_ = -1;
+        return false;
+    }
+
+    stop_flag_.store(false);
+    running_.store(true);
+    thread_ = std::thread(&SpaDaemon::loop, this);
+    NCP_LOG_INFO(std::string("[SPA] daemon listening on UDP ") + bind_addr_ +
+                 ":" + std::to_string(port_));
+    return true;
+#endif
+}
+
+void SpaDaemon::stop() {
+    stop_flag_.store(true);
+    if (thread_.joinable()) thread_.join();
+#ifndef _WIN32
+    if (sock_ >= 0) {
+        ::close(sock_);
+        sock_ = -1;
+    }
+#endif
+    running_.store(false);
+}
+
+void SpaDaemon::loop() {
+#ifndef _WIN32
+    std::vector<uint8_t> buf(SPA_PACKET_SIZE + 64);
+    while (!stop_flag_.load()) {
+        struct sockaddr_in src{};
+        socklen_t src_len = sizeof(src);
+        const ssize_t n = ::recvfrom(sock_, buf.data(), buf.size(), 0,
+                                     reinterpret_cast<struct sockaddr*>(&src), &src_len);
+        if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) continue;  // 1 s tick
+            if (stop_flag_.load()) break;
+            NCP_LOG_WARN(std::string("[SPA] recvfrom error: ") + std::strerror(errno));
+            continue;
+        }
+        char ip_str[INET_ADDRSTRLEN] = {0};
+        ::inet_ntop(AF_INET, &src.sin_addr, ip_str, sizeof(ip_str));
+        server_.process_packet(buf.data(), static_cast<size_t>(n), ip_str);
+        // Never send replies — the port must stay silent.
+    }
+#endif
+}
+
+} // namespace ncp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(ncp_tests
     test_r13_fixes.cpp       # Tests for R11-R13 critical fixes
     test_thread_safety.cpp   # Thread safety verification tests
     test_bypass_features.cpp # Hostlist/proxy/blockcheck/zapret-import/detector
+    test_spa.cpp            # Enterprise SPA (Ed25519 + ipset) tests
 )
 
 target_link_libraries(ncp_tests

--- a/tests/test_spa.cpp
+++ b/tests/test_spa.cpp
@@ -1,0 +1,399 @@
+#include <gtest/gtest.h>
+#include "ncp_spa.hpp"
+
+#include <sodium.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace ncp;
+
+// ============================================================================
+// Mock access controller — records every grant call
+// ============================================================================
+
+class MockAccessController : public IAccessController {
+public:
+    struct Call {
+        std::string ip;
+        uint8_t proto;
+        uint16_t port;
+        uint32_t ttl;
+    };
+
+    std::vector<Call> calls;
+
+    bool grant(const std::string& src_ip, uint8_t proto,
+               uint16_t port, uint32_t ttl_sec) override {
+        calls.push_back({src_ip, proto, port, ttl_sec});
+        return true;
+    }
+};
+
+// ============================================================================
+// Fixture
+// ============================================================================
+
+class SpaTest : public ::testing::Test {
+protected:
+    std::shared_ptr<MockAccessController> mock;
+    std::unique_ptr<SpaServer> server;
+
+    void SetUp() override {
+        mock = std::make_shared<MockAccessController>();
+        server.reset(new SpaServer());
+        server->set_access_controller(mock);
+    }
+
+    void authorize(const SpaClient& c) {
+        std::vector<uint8_t> pk;
+        ASSERT_TRUE(spa_base64_decode(c.pubkey_base64(), pk));
+        ASSERT_EQ(pk.size(), 32u);
+        ASSERT_TRUE(server->add_authorized_key(pk.data(), pk.size()));
+    }
+};
+
+// ============================================================================
+// Roundtrip: keygen -> build -> verify -> GRANTED with exact grant params
+// ============================================================================
+
+TEST_F(SpaTest, KeygenBuildVerifyRoundtrip) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    ASSERT_TRUE(client.has_key());
+    authorize(client);
+
+    auto pkt = client.build_packet(6, 22, 600);
+    ASSERT_EQ(pkt.size(), SPA_PACKET_SIZE);
+    EXPECT_EQ(pkt[0], 'S');
+    EXPECT_EQ(pkt[1], 'P');
+    EXPECT_EQ(pkt[2], SPA_VERSION);
+
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::GRANTED);
+
+    ASSERT_EQ(mock->calls.size(), 1u);
+    EXPECT_EQ(mock->calls[0].ip, "192.0.2.10");
+    EXPECT_EQ(mock->calls[0].proto, 6u);
+    EXPECT_EQ(mock->calls[0].port, 22u);
+    EXPECT_EQ(mock->calls[0].ttl, 600u);
+}
+
+// key_id must equal BLAKE2b-64(pubkey) first 8 bytes
+TEST_F(SpaTest, KeyIdMatchesBlake2b64) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    std::vector<uint8_t> pk;
+    ASSERT_TRUE(spa_base64_decode(client.pubkey_base64(), pk));
+    std::array<uint8_t, 8> hash{};
+    crypto_generichash(hash.data(), hash.size(), pk.data(), pk.size(), nullptr, 0);
+    SpaKeyId id = client.key_id();
+    EXPECT_EQ(std::memcmp(id.data(), hash.data(), 8), 0);
+}
+
+// ============================================================================
+// Corrupted payload -> BAD_SIGNATURE
+// ============================================================================
+
+TEST_F(SpaTest, FlippedByteGivesBadSignature) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    auto pkt = client.build_packet(6, 22, 0);
+    ASSERT_EQ(pkt.size(), SPA_PACKET_SIZE);
+    pkt[37] ^= 0x01;  // flip one payload byte inside the signed region (port LSB)
+
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::BAD_SIGNATURE);
+    EXPECT_TRUE(mock->calls.empty());
+}
+
+// ============================================================================
+// Unknown key_id -> UNKNOWN_KEY
+// ============================================================================
+
+TEST_F(SpaTest, UnknownKeyRejected) {
+    SpaClient known, stranger;
+    ASSERT_TRUE(known.generate());
+    ASSERT_TRUE(stranger.generate());
+    authorize(known);  // server only knows `known`
+
+    auto pkt = stranger.build_packet(6, 22, 0);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::UNKNOWN_KEY);
+    EXPECT_TRUE(mock->calls.empty());
+}
+
+// ============================================================================
+// Stale timestamp -> STALE_TIMESTAMP
+// ============================================================================
+
+TEST_F(SpaTest, StaleTimestampRejected) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    const uint64_t now_s = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    auto pkt = client.build_packet_ts(6, 22, 0, now_s - 120);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::STALE_TIMESTAMP);
+    EXPECT_TRUE(mock->calls.empty());
+}
+
+// Timestamp exactly at the edge of the window is still accepted
+TEST_F(SpaTest, TimestampAtWindowEdgeAccepted) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    const uint64_t now_s = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    auto pkt = client.build_packet_ts(6, 22, 0, now_s - 59);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::GRANTED);
+}
+
+// ============================================================================
+// Replay: same packet twice -> second is REPLAY
+// ============================================================================
+
+TEST_F(SpaTest, ReplayRejected) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    auto pkt = client.build_packet(6, 22, 0);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::GRANTED);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::REPLAY);
+    EXPECT_EQ(mock->calls.size(), 1u);
+}
+
+// ============================================================================
+// Two different clients — each GRANTED
+// ============================================================================
+
+TEST_F(SpaTest, TwoClientsBothGranted) {
+    SpaClient alice, bob;
+    ASSERT_TRUE(alice.generate());
+    ASSERT_TRUE(bob.generate());
+    authorize(alice);
+    authorize(bob);
+    EXPECT_EQ(server->authorized_key_count(), 2u);
+
+    auto pa = alice.build_packet(6, 22, 100);
+    auto pb = bob.build_packet(17, 51820, 200);
+
+    EXPECT_EQ(server->process_packet(pa, "192.0.2.1"), SpaResult::GRANTED);
+    EXPECT_EQ(server->process_packet(pb, "192.0.2.2"), SpaResult::GRANTED);
+
+    ASSERT_EQ(mock->calls.size(), 2u);
+    EXPECT_EQ(mock->calls[0].ip, "192.0.2.1");
+    EXPECT_EQ(mock->calls[0].proto, 6u);
+    EXPECT_EQ(mock->calls[1].ip, "192.0.2.2");
+    EXPECT_EQ(mock->calls[1].proto, 17u);
+    EXPECT_EQ(mock->calls[1].port, 51820u);
+}
+
+// ============================================================================
+// TTL clamping: requested_ttl clamped to max_ttl; 0 -> default_ttl
+// ============================================================================
+
+TEST_F(SpaTest, TtlClampedToMax) {
+    SpaServer::Config cfg;
+    cfg.default_ttl_sec = 300;
+    cfg.max_ttl_sec = 86400;
+    server.reset(new SpaServer(cfg));
+    server->set_access_controller(mock);
+
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    auto pkt = client.build_packet(6, 22, 99999999);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::GRANTED);
+    ASSERT_EQ(mock->calls.size(), 1u);
+    EXPECT_EQ(mock->calls[0].ttl, 86400u);
+}
+
+TEST_F(SpaTest, TtlZeroUsesServerDefault) {
+    SpaServer::Config cfg;
+    cfg.default_ttl_sec = 300;
+    cfg.max_ttl_sec = 86400;
+    server.reset(new SpaServer(cfg));
+    server->set_access_controller(mock);
+
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    auto pkt = client.build_packet(6, 22, 0);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::GRANTED);
+    ASSERT_EQ(mock->calls.size(), 1u);
+    EXPECT_EQ(mock->calls[0].ttl, 300u);
+}
+
+// ============================================================================
+// Bad format
+// ============================================================================
+
+TEST_F(SpaTest, BadFormatRejected) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    // wrong size
+    auto pkt = client.build_packet(6, 22, 0);
+    pkt.resize(128);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::BAD_FORMAT);
+
+    // bad magic
+    pkt = client.build_packet(6, 22, 0);
+    pkt[0] = 'X';
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::BAD_FORMAT);
+
+    // bad version
+    pkt = client.build_packet(6, 22, 0);
+    pkt[2] = 99;
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.10"), SpaResult::BAD_FORMAT);
+}
+
+// ============================================================================
+// authorized_keys file loading (base64 pubkey per line, '#' comments)
+// ============================================================================
+
+TEST_F(SpaTest, LoadAuthorizedKeysFile) {
+    SpaClient alice, bob;
+    ASSERT_TRUE(alice.generate());
+    ASSERT_TRUE(bob.generate());
+
+    const std::string path = "test_spa_authorized_keys.tmp";
+    {
+        std::ofstream f(path, std::ios::trunc);
+        f << "# SPA authorized keys\n";
+        f << "\n";
+        f << alice.pubkey_base64() << "\n";
+        f << "   " << bob.pubkey_base64() << "  \n";
+        f << "not-valid-base64!!!\n";  // skipped with warning
+    }
+    EXPECT_TRUE(server->load_authorized_keys(path));
+    EXPECT_EQ(server->authorized_key_count(), 2u);
+    std::remove(path.c_str());
+
+    auto pkt = bob.build_packet(6, 443, 60);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.20"), SpaResult::GRANTED);
+}
+
+TEST_F(SpaTest, LoadAuthorizedKeysMissingFile) {
+    EXPECT_FALSE(server->load_authorized_keys("definitely/does/not/exist.keys"));
+}
+
+// ============================================================================
+// Key file save/load roundtrip
+// ============================================================================
+
+TEST_F(SpaTest, KeyFileSaveLoadRoundtrip) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+
+    const std::string path = "test_spa_client.key";
+    ASSERT_TRUE(client.save_keyfile(path));
+
+    SpaClient loaded;
+    ASSERT_TRUE(loaded.load_keyfile(path));
+    std::remove(path.c_str());
+
+    EXPECT_EQ(loaded.key_id(), client.key_id());
+    EXPECT_EQ(loaded.pubkey_base64(), client.pubkey_base64());
+
+    // A packet built by the loaded key must verify
+    authorize(client);
+    auto pkt = loaded.build_packet(6, 22, 10);
+    EXPECT_EQ(server->process_packet(pkt, "192.0.2.30"), SpaResult::GRANTED);
+}
+
+// ============================================================================
+// IpSetAccessController — dry_run records the exact command, executes nothing
+// ============================================================================
+
+TEST(SpaIpSetTest, DryRunRecordsExactCommands) {
+    IpSetAccessController ctrl("ncp_spa_allow", true /*dry_run*/);
+    std::vector<std::string> executed;
+    ctrl.set_command_runner([&](const std::string& cmd) -> int {
+        executed.push_back(cmd);
+        return 0;
+    });
+
+    EXPECT_TRUE(ctrl.grant("203.0.113.7", 6, 22, 300));
+
+    // In dry-run the runner must never be invoked
+    EXPECT_TRUE(executed.empty());
+    EXPECT_EQ(ctrl.last_command(),
+              "ipset add ncp_spa_allow 203.0.113.7 timeout 300 -exist");
+}
+
+TEST(SpaIpSetTest, RealModeRunsExactCommandsViaRunner) {
+    IpSetAccessController ctrl("ncp_spa_allow", false /*dry_run*/);
+    std::vector<std::string> executed;
+    ctrl.set_command_runner([&](const std::string& cmd) -> int {
+        executed.push_back(cmd);
+        return 0;
+    });
+
+    EXPECT_TRUE(ctrl.grant("203.0.113.7", 6, 22, 300));
+
+    ASSERT_EQ(executed.size(), 2u);
+    EXPECT_EQ(executed[0], "ipset create ncp_spa_allow hash:ip timeout 0 -exist");
+    EXPECT_EQ(executed[1], "ipset add ncp_spa_allow 203.0.113.7 timeout 300 -exist");
+    EXPECT_EQ(ctrl.last_command(), executed[1]);
+
+    // Second grant: set already ensured, only the add runs
+    EXPECT_TRUE(ctrl.grant("203.0.113.8", 17, 51820, 60));
+    ASSERT_EQ(executed.size(), 3u);
+    EXPECT_EQ(executed[2], "ipset add ncp_spa_allow 203.0.113.8 timeout 60 -exist");
+}
+
+TEST(SpaIpSetTest, RunnerFailurePropagates) {
+    IpSetAccessController ctrl("ncp_spa_allow", false);
+    ctrl.set_command_runner([](const std::string&) -> int { return 1; });
+    EXPECT_FALSE(ctrl.grant("203.0.113.7", 6, 22, 300));
+}
+
+TEST(SpaIpSetTest, IptablesRuleHint) {
+    EXPECT_EQ(IpSetAccessController::iptables_rule_hint(6, 22, "ncp_spa_allow"),
+              "iptables -A INPUT -p tcp --dport 22 -m set ! --match-set ncp_spa_allow src -j DROP");
+    EXPECT_EQ(IpSetAccessController::iptables_rule_hint(17, 51820, "s"),
+              "iptables -A INPUT -p udp --dport 51820 -m set ! --match-set s src -j DROP");
+}
+
+// ============================================================================
+// Full end-to-end: daemon on 127.0.0.1 + client knock
+// ============================================================================
+
+TEST_F(SpaTest, DaemonEndToEndLoopback) {
+    SpaClient client;
+    ASSERT_TRUE(client.generate());
+    authorize(client);
+
+    // fixed high port that is very likely free in CI
+    SpaDaemon d2(*server, 54917, "127.0.0.1");
+    if (!d2.start()) {
+        GTEST_SKIP() << "UDP port 54917 unavailable";
+    }
+    EXPECT_TRUE(client.knock("127.0.0.1", 54917, 6, 22, 42));
+
+    // give the receive loop a moment
+    for (int i = 0; i < 50 && mock->calls.empty(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    d2.stop();
+
+    ASSERT_EQ(mock->calls.size(), 1u);
+    EXPECT_EQ(mock->calls[0].ip, "127.0.0.1");
+    EXPECT_EQ(mock->calls[0].port, 22u);
+    EXPECT_EQ(mock->calls[0].ttl, 42u);
+}


### PR DESCRIPTION
## Enterprise SPA module (`ncp spa`)

Single Packet Authorization with **Ed25519 asymmetric signatures** + **ipset**-based dynamic gate control — an upgrade over the existing symmetric-HMAC SPA inside PortKnock (which is vulnerable to replay/timing analysis and keeps the gate in-memory only).

### Wire format (256-byte UDP payload)
`magic "SP" | v1 | key_id(8)=BLAKE2b-64(pubkey) | timestamp(8) | nonce(16) | proto(1) | allow_port(2) | ttl(4) | Ed25519 sig(64) over first 42 bytes | CSPRNG padding`

### Server pipeline
1. format/magic/version → 2. key_id in authorized_keys → 3. timestamp ±60 s → 4. per-key nonce replay cache (120 s TTL + janitor) → 5. Ed25519 verify → 6. `ipset add ncp_spa_allow <src_ip> timeout <ttl> -exist`

Gate rule (printed at startup): `iptables -A INPUT -p tcp --dport <port> -m set ! --match-set ncp_spa_allow src -j DROP`

### CLI
```
ncp spa keygen --out client
ncp spa serve --authorized-keys keys.txt --port 54117 --set-name ncp_spa_allow --default-ttl 300 [--dry-run]
ncp spa knock <ip> --key client.key --allow-port 443 --ttl 300 [--send-twice]  # replay self-test
```

### Tests
- **22 new gtest cases** (roundtrip, tamper→BAD_SIGNATURE, UNKNOWN_KEY, STALE_TIMESTAMP, REPLAY, TTL clamp, dry-run command verification, daemon end-to-end on 127.0.0.1). Full suite: **667 tests, 659 passed, 8 skipped (I2P, pre-existing), 0 failed** — no regressions.
- **Docker DPI Lab integration**: pre-knock curl times out (DROP) → valid knock → `GRANTED`, ipset member with TTL countdown, curl 200 → identical re-sent packet → `REPLAY` → TTL expiry → blocked again → unknown key → `UNKNOWN_KEY`, still blocked.

### Security properties
- Asymmetric: server stores only public keys — server compromise doesn't leak client signing capability.
- Anti-replay: nonce cache + timestamp window.
- Least exposure: access granted per source IP, per port, with automatic expiry.

Files: `src/core/include/ncp_spa.hpp`, `src/core/src/ncp_spa.cpp`, `tests/test_spa.cpp`, CLI wiring in `src/cli/main.cpp`, CMake lists, README section.