### PR TITLE
fix(build): Windows/MSVC compatibility for reality+fog, release builds without tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           conan install . --build=missing -of=build
           
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON -DENABLE_TESTS=OFF
         
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}} -j$(nproc)
@@ -66,7 +66,7 @@ jobs:
           conan install . --build=missing -of=build
           
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON -DENABLE_TESTS=OFF
         
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}} -j$(sysctl -n hw.ncpu)
@@ -104,7 +104,7 @@ jobs:
           conan install . --build=missing -of=build
           
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON -DENABLE_TESTS=OFF
         
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}

--- a/src/core/src/ncp_fog.cpp
+++ b/src/core/src/ncp_fog.cpp
@@ -15,12 +15,14 @@
 
 #include <sodium.h>
 
+#ifndef _WIN32
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/select.h>
+#endif
 
 // Minimal local logging (standalone-build friendly).
 #ifndef NCPX_FOG_LOG
@@ -193,6 +195,10 @@ FogNode::~FogNode() { stop(); }
 
 FogError FogNode::start() {
     if (sock_ >= 0) return FogError::OK;
+#ifdef _WIN32
+    NCPX_FOG_LOG("ERROR", "fog node networking is not supported on Windows yet");
+    return FogError::NOT_BOUND;
+#else
     sock_ = ::socket(AF_INET, SOCK_DGRAM, 0);
     if (sock_ < 0) {
         NCPX_FOG_LOG("ERROR", "socket() failed");
@@ -216,13 +222,16 @@ FogError FogNode::start() {
         bound_port_ = ntohs(addr.sin_port);
     }
     return FogError::OK;
+#endif
 }
 
 void FogNode::stop() {
+#ifndef _WIN32
     if (sock_ >= 0) {
         ::close(sock_);
         sock_ = -1;
     }
+#endif
 }
 
 bool FogNode::running() const { return sock_ >= 0; }
@@ -298,8 +307,13 @@ FogError FogNode::send_route_ad(const FogPeerInfo& neighbour, uint64_t now) {
     return send_frame_to(f, neighbour.ipv4, neighbour.port);
 }
 
-FogError FogNode::send_frame_to(const FogFrame& f, uint32_t ip, uint16_t port) {
+FogError FogNode::send_frame_to([[maybe_unused]] const FogFrame& f,
+                                [[maybe_unused]] uint32_t ip,
+                                [[maybe_unused]] uint16_t port) {
     if (sock_ < 0) return FogError::NOT_BOUND;
+#ifdef _WIN32
+    return FogError::NOT_BOUND;
+#else
     std::vector<uint8_t> buf = f.pack();
     sockaddr_in dst{};
     dst.sin_family = AF_INET;
@@ -312,6 +326,7 @@ FogError FogNode::send_frame_to(const FogFrame& f, uint32_t ip, uint16_t port) {
         return FogError::SEND_FAILED;
     }
     return FogError::OK;
+#endif
 }
 
 FogError FogNode::forward(const FogFrame& f, uint64_t now) {
@@ -452,8 +467,12 @@ void FogNode::handle_frame(const FogFrame& f, uint32_t src_ip, uint16_t src_port
     // No route: the frame silently dies here (NO_ROUTE from forward()).
 }
 
-int FogNode::poll(int timeout_ms, uint64_t now) {
+int FogNode::poll([[maybe_unused]] int timeout_ms,
+                  [[maybe_unused]] uint64_t now) {
     if (sock_ < 0) return 0;
+#ifdef _WIN32
+    return 0;
+#else
     fd_set rfds;
     FD_ZERO(&rfds);
     FD_SET(sock_, &rfds);
@@ -478,6 +497,7 @@ int FogNode::poll(int timeout_ms, uint64_t now) {
         ++handled;
     }
     return handled;
+#endif
 }
 
 bool FogNode::inbox_pop(std::vector<uint8_t>& out) {

--- a/src/core/src/ncp_reality.cpp
+++ b/src/core/src/ncp_reality.cpp
@@ -8,6 +8,7 @@
 
 #include <sodium.h>
 
+#ifndef _WIN32
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -15,6 +16,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#endif
 
 namespace ncp {
 
@@ -102,7 +104,12 @@ bool split_sni(const std::string& sni, std::string& token,
 }
 
 // Write all bytes, retrying on EINTR; MSG_NOSIGNAL against SIGPIPE.
-bool write_all(int fd, const uint8_t* data, size_t len) noexcept {
+// Windows: the TCP splice path is not supported yet, stubbed out.
+bool write_all([[maybe_unused]] int fd, [[maybe_unused]] const uint8_t* data,
+               [[maybe_unused]] size_t len) noexcept {
+#ifdef _WIN32
+    return false;
+#else
     size_t off = 0;
     while (off < len) {
         const ssize_t n = ::send(fd, data + off, len - off, MSG_NOSIGNAL);
@@ -114,9 +121,14 @@ bool write_all(int fd, const uint8_t* data, size_t len) noexcept {
         off += static_cast<size_t>(n);
     }
     return true;
+#endif
 }
 
-int connect_to(const std::string& host, uint16_t port) noexcept {
+int connect_to([[maybe_unused]] const std::string& host,
+               [[maybe_unused]] uint16_t port) noexcept {
+#ifdef _WIN32
+    return -1;  // TCP fallback dial is not supported on Windows yet
+#else
     struct addrinfo hints {};
     hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
@@ -135,6 +147,7 @@ int connect_to(const std::string& host, uint16_t port) noexcept {
     }
     ::freeaddrinfo(res);
     return fd;
+#endif
 }
 
 } // anonymous namespace
@@ -320,7 +333,11 @@ RealityServer::Decision RealityServer::classify(const uint8_t* clienthello,
     return Decision::FALLBACK;
 }
 
-void RealityServer::splice(int fd_a, int fd_b) noexcept {
+void RealityServer::splice([[maybe_unused]] int fd_a,
+                           [[maybe_unused]] int fd_b) noexcept {
+#ifdef _WIN32
+    return;  // bidirectional splice is not supported on Windows yet
+#else
     if (fd_a < 0 || fd_b < 0) return;
     bool read_a = true;  // still reading from fd_a
     bool read_b = true;  // still reading from fd_b
@@ -366,9 +383,14 @@ void RealityServer::splice(int fd_a, int fd_b) noexcept {
             }
         }
     }
+#endif
 }
 
-bool RealityServer::handle_client(int client_fd, uint64_t now) const noexcept {
+bool RealityServer::handle_client([[maybe_unused]] int client_fd,
+                                  [[maybe_unused]] uint64_t now) const noexcept {
+#ifdef _WIN32
+    return false;  // fallback relay is not supported on Windows yet
+#else
     if (client_fd < 0) return false;
 
     // Read the ClientHello (single record, capped at 16 KiB).
@@ -408,6 +430,7 @@ bool RealityServer::handle_client(int client_fd, uint64_t now) const noexcept {
     splice(client_fd, upstream);
     ::close(upstream);
     return true;
+#endif
 }
 
 } // namespace ncp


### PR DESCRIPTION
## Проблема
Release-сборка для Windows (MSVC) падала бы на новых enterprise-модулях:
- `ncp_reality.cpp` и `ncp_fog.cpp` безусловно включали POSIX-заголовки (`sys/socket.h`, `poll.h`, `netdb.h` и т.д.), которых нет в MSVC;
- `release.yml` не передавал `-DENABLE_TESTS=OFF`, а тесты по умолчанию ON — POSIX-socket тестовые файлы тоже ломали бы Windows-сборку.

## Изменения
- **ncp_reality.cpp**: инклюды под `#ifndef _WIN32`; стабы `write_all`/`connect_to`/`RealityServer::splice`/`RealityServer::handle_client` на `_WIN32` (TCP-splice путь пока не поддержан). `RealityAuth`/`extract_sni`/`classify` остаются полностью портируемыми.
- **ncp_fog.cpp**: инклюды под `#ifndef _WIN32`; `FogNode::start` возвращает `NOT_BOUND`, `stop`/`send_frame_to`/`poll` — no-op на `_WIN32`. `FogFrame`/`FogPeerTable` портируемы.
- **release.yml**: `-DENABLE_TESTS=OFF` во всех трёх платформенных джобах.

## Верификация
- `g++ -fsyntax-only` (Linux) — OK для обоих файлов;
- `x86_64-w64-mingw32-g++ -fsyntax-only` (кросс-проверка `_WIN32`-веток) — OK;
- `ncp_tests --gtest_filter="*Reality*:*Fog*"` — **18/18 PASSED** на Linux, включая реальный UDP-relay тест (`FogNode.UdpRelayChainABC`).

Разблокирует создание GitHub Release v1.5.0 (job `create-release` требует все 3 платформы).