### PR TITLE
feat(release): полная поддержка Windows без заглушек + починка release-сборок

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,11 @@
 name: npm Publish
 
 on:
-  release:
-    types: [published]
+  # NOTE: автоматический триггер `release: types: [published]` намеренно
+  # отключён до добавления секрета NPM_TOKEN в Settings -> Secrets.
+  # После добавления секрета верните блок:
+  #   release:
+  #     types: [published]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,32 +19,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake build-essential libpcap-dev
-          sudo apt-get install -y qt6-base-dev qt6-charts-dev
-          pip install conan
-          
-      - name: Setup Conan
-        run: |
-          conan profile detect
-          conan install . --build=missing -of=build
-          
+          for i in 1 2 3; do
+            sudo apt-get update && break || { echo "apt-get update attempt $i failed, retrying..."; sleep 15; }
+          done
+          sudo apt-get install -y --no-install-recommends \
+            cmake build-essential pkg-config \
+            libpcap-dev libssl-dev libsodium-dev libwebsockets-dev \
+            qt6-base-dev qt6-charts-dev
+
       - name: Configure CMake
         run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON -DENABLE_TESTS=OFF
-        
+
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}} -j$(nproc)
-        
+
       - name: Package
         run: |
           mkdir -p release/ncp-linux-x64
           cp build/bin/ncp release/ncp-linux-x64/
           cp README.md LICENSE release/ncp-linux-x64/
           tar -czvf ncp-linux-x64.tar.gz -C release ncp-linux-x64
-          
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -55,29 +53,25 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install dependencies
         run: |
-          brew install cmake conan qt@6 libpcap
-          
-      - name: Setup Conan
-        run: |
-          conan profile detect
-          conan install . --build=missing -of=build
-          
+          brew update
+          brew install cmake libsodium libwebsockets qt@6 libpcap
+
       - name: Configure CMake
         run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON -DENABLE_TESTS=OFF
-        
+
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}} -j$(sysctl -n hw.ncpu)
-        
+
       - name: Package
         run: |
           mkdir -p release/ncp-macos-x64
           cp build/bin/ncp release/ncp-macos-x64/
           cp README.md LICENSE release/ncp-macos-x64/
           tar -czvf ncp-macos-x64.tar.gz -C release ncp-macos-x64
-          
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -88,35 +82,52 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
           version: '6.6.0'
           modules: 'qtcharts'
-          
-      - name: Install Conan
-        run: pip install conan
-        
-      - name: Setup Conan
+
+      - name: Cache vcpkg
+        uses: actions/cache@v4
+        with:
+          path: C:\vcpkg\installed
+          key: vcpkg-release-deps-x64-windows-${{ hashFiles('.github/workflows/release.yml') }}
+
+      - name: Install vcpkg and dependencies
+        shell: cmd
         run: |
-          conan profile detect
-          conan install . --build=missing -of=build
-          
+          if not exist C:\vcpkg\vcpkg.exe (
+            git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+            C:\vcpkg\bootstrap-vcpkg.bat
+          )
+          C:\vcpkg\vcpkg install libsodium:x64-windows libwebsockets:x64-windows openssl:x64-windows
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DENABLE_GUI=ON -DENABLE_TESTS=OFF
-        
+        shell: pwsh
+        run: |
+          cmake -B build `
+            -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} `
+            -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
+            -DENABLE_GUI=ON -DENABLE_TESTS=OFF
+
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}}
-        
+
       - name: Package
+        shell: pwsh
         run: |
-          mkdir release\ncp-windows-x64
-          copy build\bin\Release\ncp.exe release\ncp-windows-x64\
-          copy README.md release\ncp-windows-x64\
-          copy LICENSE release\ncp-windows-x64\
-          Compress-Archive -Path release\ncp-windows-x64 -DestinationPath ncp-windows-x64.zip
-          
+          New-Item -ItemType Directory -Path release\ncp-windows-x64 -Force | Out-Null
+          Copy-Item build\bin\Release\ncp.exe release\ncp-windows-x64\
+          Copy-Item README.md, LICENSE release\ncp-windows-x64\
+          windeployqt --release --no-translations release\ncp-windows-x64\ncp.exe 2>$null
+          Copy-Item C:\vcpkg\installed\x64-windows\bin\*.dll release\ncp-windows-x64\
+          Compress-Archive -Path release\ncp-windows-x64 -DestinationPath ncp-windows-x64.zip -Force
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -130,7 +141,7 @@ jobs:
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
-        
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -34,6 +34,7 @@
 #include "ncp_porthop.hpp"
 #include "ncp_fog.hpp"
 #include "ncp_xdp.hpp"
+#include "ncp_winsock_init.hpp"
 
 #include <iostream>
 #include <string>
@@ -3719,8 +3720,51 @@ void handle_reality(const std::vector<std::string>& args) {
     }
 
 #ifdef _WIN32
-    std::cerr << "[!] reality serve is not supported on Windows\n";
-    return;
+    if (!ncp::winsock_init()) {
+        std::cerr << "[!] WSAStartup failed\n";
+        return;
+    }
+    ncp::RealityServer server(cfg);
+
+    const SOCKET listen_fd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listen_fd == INVALID_SOCKET) {
+        std::cerr << "[!] socket() failed\n";
+        return;
+    }
+    int one = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR,
+                 reinterpret_cast<const char*>(&one), sizeof(one));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(cfg.listen_port);
+    if (::bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 ||
+        ::listen(listen_fd, 128) != 0) {
+        std::cerr << "[!] Cannot bind/listen on TCP port " << cfg.listen_port << "\n";
+        ::closesocket(listen_fd);
+        return;
+    }
+    std::cout << "[*] Reality server running — Ctrl-C to stop\n";
+
+    g_running = 1;
+    while (g_running) {
+        WSAPOLLFD pfd{};
+        pfd.fd = listen_fd;
+        pfd.events = POLLIN;
+        if (::WSAPoll(&pfd, 1, 200) <= 0) continue;
+        sockaddr_in caddr{};
+        int clen = sizeof(caddr);
+        const SOCKET cfd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&caddr), &clen);
+        if (cfd == INVALID_SOCKET) continue;
+        std::thread([&server, cfd]() {
+            const uint64_t now = static_cast<uint64_t>(std::time(nullptr));
+            server.handle_client(cfd, now);
+            ::shutdown(cfd, SD_BOTH);
+            ::closesocket(cfd);
+        }).detach();
+    }
+    ::closesocket(listen_fd);
+    std::cout << "[*] Reality server stopped\n";
 #else
     ncp::RealityServer server(cfg);
 
@@ -4153,10 +4197,6 @@ void handle_fog(const std::vector<std::string>& args) {
               << "  ID:    " << cfg.id.to_hex() << "\n"
               << "  Bind:  UDP 0.0.0.0:" << node.bound_port() << "\n";
 
-#ifdef _WIN32
-    if (!peer_opts.empty())
-        std::cerr << "[!] --peer is not supported on Windows\n";
-#else
     // Static neighbours: registered with a placeholder id (real ids are
     // learned from incoming frames) and seeded with a ROUTE_AD gossip.
     std::vector<ncp::FogPeerInfo> neighbours;
@@ -4184,7 +4224,6 @@ void handle_fog(const std::vector<std::string>& args) {
         neighbours.push_back(info);
         std::cout << "  Peer:  " << p << "\n";
     }
-#endif
 
     std::cout << "[*] Running — Ctrl-C to stop\n";
     g_running = 1;
@@ -4197,7 +4236,6 @@ void handle_fog(const std::vector<std::string>& args) {
             const std::string text(msg.begin(), msg.end());
             std::cout << "[fog] DATA delivered: \"" << text << "\"\n";
         }
-#ifndef _WIN32
         // Periodic table decay + re-gossip to static neighbours.
         if (std::chrono::steady_clock::now() - last_gossip >
             std::chrono::seconds(15)) {
@@ -4206,7 +4244,6 @@ void handle_fog(const std::vector<std::string>& args) {
                 node.send_route_ad(n, now);
             last_gossip = std::chrono::steady_clock::now();
         }
-#endif
     }
     node.stop();
     std::cout << "[*] Fog node stopped (relayed " << node.relayed()

--- a/src/core/include/ncp_fog.hpp
+++ b/src/core/include/ncp_fog.hpp
@@ -32,6 +32,8 @@
 #include <mutex>
 #include <optional>
 
+#include "ncp_winsock_init.hpp"
+
 namespace ncp {
 
 // ===== Peer identity =====
@@ -202,7 +204,7 @@ private:
 
     Config        cfg_;
     FogPeerTable  table_;
-    int           sock_ = -1;
+    socket_t      sock_ = kInvalidSocket;
     uint16_t      bound_port_ = 0;
     uint64_t      seq_counter_ = 0;
 

--- a/src/core/include/ncp_porthop.hpp
+++ b/src/core/include/ncp_porthop.hpp
@@ -42,6 +42,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ncp_winsock_init.hpp"
+
 namespace ncp {
 
 // ===== Frame flags =====
@@ -200,7 +202,7 @@ private:
     };
 
     HopSchedule schedule_;
-    std::vector<int> sockets_;           // one fd per bound port
+    std::vector<socket_t> sockets_;      // one socket per bound port
     std::vector<uint16_t> bound_ports_;  // parallel to sockets_
     std::unordered_map<uint64_t, SessionState> sessions_;
     mutable std::mutex mutex_;
@@ -247,7 +249,7 @@ private:
     HopSchedule schedule_;
     uint64_t session_id_;
     PortHopSession session_;
-    int socket_ = -1;
+    socket_t socket_ = kInvalidSocket;
     uint16_t local_port_ = 0;
 };
 

--- a/src/core/include/ncp_reality.hpp
+++ b/src/core/include/ncp_reality.hpp
@@ -41,6 +41,8 @@
 #include <memory>
 #include <string>
 
+#include "ncp_winsock_init.hpp"
+
 namespace ncp {
 
 // ===== Classification result =====
@@ -121,16 +123,18 @@ public:
     static bool extract_sni(const uint8_t* clienthello, size_t len,
                             std::string& out_sni) noexcept;
 
-    // Bidirectional byte splicing between two connected sockets using poll().
-    // Half-close aware: EOF on one side shutdown()s the opposite write half;
-    // returns once both directions are closed. Single-threaded.
-    static void splice(int fd_a, int fd_b) noexcept;
+    // Bidirectional byte splicing between two connected sockets using
+    // poll() (POSIX) / WSAPoll() (Windows). Half-close aware: EOF on one
+    // side shutdown()s the opposite write half; returns once both
+    // directions are closed. Single-threaded.
+    // socket_t is int on POSIX and Winsock SOCKET on Windows.
+    static void splice(socket_t fd_a, socket_t fd_b) noexcept;
 
     // Read the ClientHello from client_fd, classify it, connect to the
     // internal service (AUTHORIZED) or the fallback domain (FALLBACK) and
     // splice the connection. NOT_TLS connections are closed immediately.
     // Returns true if the connection was spliced to an upstream.
-    bool handle_client(int client_fd, uint64_t now) const noexcept;
+    bool handle_client(socket_t client_fd, uint64_t now) const noexcept;
 
     const RealityConfig& config() const noexcept { return cfg_; }
 

--- a/src/core/include/ncp_spa.hpp
+++ b/src/core/include/ncp_spa.hpp
@@ -51,6 +51,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ncp_winsock_init.hpp"
 #include "ncp_crypto.hpp"
 #include "ncp_secure_memory.hpp"
 
@@ -266,7 +267,7 @@ private:
     SpaServer& server_;
     uint16_t port_;
     std::string bind_addr_;
-    int sock_ = -1;
+    socket_t sock_ = kInvalidSocket;
     std::atomic<bool> stop_flag_{false};
     std::atomic<bool> running_{false};
     std::thread thread_;

--- a/src/core/include/ncp_winsock_init.hpp
+++ b/src/core/include/ncp_winsock_init.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+/**
+ * @file ncp_winsock_init.hpp
+ * @brief Shared Winsock2 bootstrap + portable socket-handle type.
+ *
+ * Winsock requires WSAStartup() before any socket API is used. This header
+ * provides a thread-safe, call-once initializer used by all enterprise
+ * networking modules (reality / fog / spa / porthop) and the CLI.
+ *
+ * WSACleanup is intentionally NOT registered via atexit(): Winsock
+ * reference-counts WSAStartup calls and the OS reclaims everything at
+ * process exit. An atexit handler could fire while detached relay threads
+ * (e.g. the reality splice workers) are still inside Winsock calls, which
+ * is a use-after-cleanup race with no upside — there is nothing to flush.
+ *
+ * Include order note: on _WIN32 this header pulls <winsock2.h> and
+ * <ws2tcpip.h>. winsock2.h defines _WINSOCKAPI_, so a later <windows.h>
+ * in the same translation unit will skip <winsock.h> (the classic
+ * winsock.h/winsock2.h conflict). The project also sets
+ * WIN32_LEAN_AND_MEAN globally (top-level CMakeLists), which keeps
+ * <windows.h> from dragging <winsock.h> in at all.
+ */
+
+#include <cstdint>
+
+#ifdef _WIN32
+#include <mutex>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
+namespace ncp {
+
+#ifdef _WIN32
+/// Portable socket handle: Winsock SOCKET (UINT_PTR) on Windows, int fd
+/// elsewhere. Public APIs use this type so 64-bit Windows handles are
+/// never truncated to int.
+using socket_t = SOCKET;
+inline constexpr socket_t kInvalidSocket = INVALID_SOCKET;
+#else
+using socket_t = int;
+inline constexpr socket_t kInvalidSocket = -1;
+#endif
+
+/**
+ * Ensure Winsock 2.2 is initialized (WSAStartup), exactly once per process,
+ * thread-safe. Returns true when the Winsock DLL is usable.
+ * On POSIX this is a no-op that always returns true.
+ */
+inline bool winsock_init() noexcept {
+#ifdef _WIN32
+    static std::once_flag s_once;
+    static bool s_ok = false;
+    std::call_once(s_once, [] {
+        WSADATA wsa{};
+        s_ok = (::WSAStartup(MAKEWORD(2, 2), &wsa) == 0);
+    });
+    return s_ok;
+#else
+    return true;
+#endif
+}
+
+} // namespace ncp

--- a/src/core/src/ncp_fog.cpp
+++ b/src/core/src/ncp_fog.cpp
@@ -15,7 +15,10 @@
 
 #include <sodium.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+// ncp_winsock_init.hpp (via ncp_fog.hpp) provides <winsock2.h>/<ws2tcpip.h>,
+// ncp::socket_t, ncp::kInvalidSocket and ncp::winsock_init().
+#else
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -194,10 +197,41 @@ FogNode::FogNode(Config cfg) : cfg_(cfg) {
 FogNode::~FogNode() { stop(); }
 
 FogError FogNode::start() {
-    if (sock_ >= 0) return FogError::OK;
+    if (sock_ != kInvalidSocket) return FogError::OK;
 #ifdef _WIN32
-    NCPX_FOG_LOG("ERROR", "fog node networking is not supported on Windows yet");
-    return FogError::NOT_BOUND;
+    if (!winsock_init()) {
+        NCPX_FOG_LOG("ERROR", "WSAStartup failed");
+        return FogError::NOT_BOUND;
+    }
+    sock_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock_ == kInvalidSocket) {
+        NCPX_FOG_LOG("ERROR", "socket() failed");
+        return FogError::NOT_BOUND;
+    }
+    // Non-blocking mode (Winsock equivalent of fcntl O_NONBLOCK).
+    u_long nb = 1;
+    if (::ioctlsocket(sock_, FIONBIO, &nb) != 0) {
+        NCPX_FOG_LOG("ERROR", "ioctlsocket(FIONBIO) failed");
+        ::closesocket(sock_);
+        sock_ = kInvalidSocket;
+        return FogError::NOT_BOUND;
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(cfg_.bind_port);
+    if (::bind(sock_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        NCPX_FOG_LOG("ERROR", "bind() failed");
+        ::closesocket(sock_);
+        sock_ = kInvalidSocket;
+        return FogError::NOT_BOUND;
+    }
+    int alen = sizeof(addr);
+    if (::getsockname(sock_, reinterpret_cast<sockaddr*>(&addr), &alen) == 0) {
+        bound_port_ = ntohs(addr.sin_port);
+    }
+    return FogError::OK;
 #else
     sock_ = ::socket(AF_INET, SOCK_DGRAM, 0);
     if (sock_ < 0) {
@@ -226,15 +260,16 @@ FogError FogNode::start() {
 }
 
 void FogNode::stop() {
-#ifndef _WIN32
-    if (sock_ >= 0) {
-        ::close(sock_);
-        sock_ = -1;
-    }
+    if (sock_ == kInvalidSocket) return;
+#ifdef _WIN32
+    ::closesocket(sock_);
+#else
+    ::close(sock_);
 #endif
+    sock_ = kInvalidSocket;
 }
 
-bool FogNode::running() const { return sock_ >= 0; }
+bool FogNode::running() const { return sock_ != kInvalidSocket; }
 uint16_t FogNode::bound_port() const { return bound_port_; }
 
 uint64_t FogNode::next_seq_unlocked() { return ++seq_counter_; }
@@ -242,7 +277,7 @@ uint64_t FogNode::next_seq_unlocked() { return ++seq_counter_; }
 FogError FogNode::send_data(const FogPeerId& target,
                             const std::vector<uint8_t>& payload,
                             uint64_t now) {
-    if (sock_ < 0) return FogError::NOT_BOUND;
+    if (sock_ == kInvalidSocket) return FogError::NOT_BOUND;
     FogFrame f;
     f.ttl = cfg_.default_ttl;
     f.type = FogMsgType::DATA;
@@ -258,7 +293,7 @@ FogError FogNode::send_data(const FogPeerId& target,
 }
 
 FogError FogNode::send_ping(const FogPeerId& target, uint64_t now) {
-    if (sock_ < 0) return FogError::NOT_BOUND;
+    if (sock_ == kInvalidSocket) return FogError::NOT_BOUND;
     FogFrame f;
     f.ttl = cfg_.default_ttl;
     f.type = FogMsgType::PING;
@@ -273,7 +308,7 @@ FogError FogNode::send_ping(const FogPeerId& target, uint64_t now) {
 }
 
 FogError FogNode::send_route_ad(const FogPeerInfo& neighbour, uint64_t now) {
-    if (sock_ < 0) return FogError::NOT_BOUND;
+    if (sock_ == kInvalidSocket) return FogError::NOT_BOUND;
     FogFrame f;
     f.ttl = 1; // gossip is one-hop
     f.type = FogMsgType::ROUTE_AD;
@@ -307,26 +342,29 @@ FogError FogNode::send_route_ad(const FogPeerInfo& neighbour, uint64_t now) {
     return send_frame_to(f, neighbour.ipv4, neighbour.port);
 }
 
-FogError FogNode::send_frame_to([[maybe_unused]] const FogFrame& f,
-                                [[maybe_unused]] uint32_t ip,
-                                [[maybe_unused]] uint16_t port) {
-    if (sock_ < 0) return FogError::NOT_BOUND;
-#ifdef _WIN32
-    return FogError::NOT_BOUND;
-#else
+FogError FogNode::send_frame_to(const FogFrame& f,
+                                uint32_t ip,
+                                uint16_t port) {
+    if (sock_ == kInvalidSocket) return FogError::NOT_BOUND;
     std::vector<uint8_t> buf = f.pack();
     sockaddr_in dst{};
     dst.sin_family = AF_INET;
     dst.sin_addr.s_addr = htonl(ip);
     dst.sin_port = htons(port);
+#ifdef _WIN32
+    const int sent = ::sendto(sock_, reinterpret_cast<const char*>(buf.data()),
+                              static_cast<int>(buf.size()), 0,
+                              reinterpret_cast<sockaddr*>(&dst), sizeof(dst));
+    if (sent != static_cast<int>(buf.size())) {
+#else
     ssize_t sent = ::sendto(sock_, buf.data(), buf.size(), 0,
                             reinterpret_cast<sockaddr*>(&dst), sizeof(dst));
     if (sent != static_cast<ssize_t>(buf.size())) {
+#endif
         NCPX_FOG_LOG("WARN", "sendto() short/failed");
         return FogError::SEND_FAILED;
     }
     return FogError::OK;
-#endif
 }
 
 FogError FogNode::forward(const FogFrame& f, uint64_t now) {
@@ -467,19 +505,20 @@ void FogNode::handle_frame(const FogFrame& f, uint32_t src_ip, uint16_t src_port
     // No route: the frame silently dies here (NO_ROUTE from forward()).
 }
 
-int FogNode::poll([[maybe_unused]] int timeout_ms,
-                  [[maybe_unused]] uint64_t now) {
-    if (sock_ < 0) return 0;
-#ifdef _WIN32
-    return 0;
-#else
+int FogNode::poll(int timeout_ms, uint64_t now) {
+    if (sock_ == kInvalidSocket) return 0;
     fd_set rfds;
     FD_ZERO(&rfds);
     FD_SET(sock_, &rfds);
     timeval tv{};
     tv.tv_sec  = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000;
+#ifdef _WIN32
+    // Winsock select() works on SOCKET handles; the nfds argument is ignored.
+    int rc = ::select(0, &rfds, nullptr, nullptr, &tv);
+#else
     int rc = ::select(sock_ + 1, &rfds, nullptr, nullptr, &tv);
+#endif
     if (rc <= 0) return 0;
 
     int handled = 0;
@@ -487,9 +526,18 @@ int FogNode::poll([[maybe_unused]] int timeout_ms,
     for (int i = 0; i < 64; ++i) {
         uint8_t buf[65535];
         sockaddr_in src{};
+#ifdef _WIN32
+        // The socket is non-blocking (FIONBIO), so the drain stops with
+        // WSAEWOULDBLOCK once the queue is empty — MSG_DONTWAIT equivalent.
+        int slen = sizeof(src);
+        const int n = ::recvfrom(sock_, reinterpret_cast<char*>(buf),
+                                 static_cast<int>(sizeof(buf)), 0,
+                                 reinterpret_cast<sockaddr*>(&src), &slen);
+#else
         socklen_t slen = sizeof(src);
         ssize_t n = ::recvfrom(sock_, buf, sizeof(buf), MSG_DONTWAIT,
                                reinterpret_cast<sockaddr*>(&src), &slen);
+#endif
         if (n <= 0) break;
         auto frame = FogFrame::parse(buf, static_cast<size_t>(n));
         if (!frame) continue;
@@ -497,7 +545,6 @@ int FogNode::poll([[maybe_unused]] int timeout_ms,
         ++handled;
     }
     return handled;
-#endif
 }
 
 bool FogNode::inbox_pop(std::vector<uint8_t>& out) {

--- a/src/core/src/ncp_porthop.cpp
+++ b/src/core/src/ncp_porthop.cpp
@@ -10,7 +10,10 @@
 #include <cstring>
 #include <sodium.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+// ncp_winsock_init.hpp (via ncp_porthop.hpp) provides <winsock2.h>/
+// <ws2tcpip.h>, ncp::socket_t, ncp::kInvalidSocket and ncp::winsock_init().
+#else
 # include <arpa/inet.h>
 # include <errno.h>
 # include <fcntl.h>
@@ -55,11 +58,16 @@ uint64_t load_u64_be(const uint8_t* p) {
     return v;
 }
 
-#ifndef _WIN32
-bool set_nonblocking(int fd) {
+bool set_nonblocking(socket_t fd) {
+#ifdef _WIN32
+    // Winsock equivalent of fcntl(O_NONBLOCK).
+    u_long nb = 1;
+    return ::ioctlsocket(fd, FIONBIO, &nb) == 0;
+#else
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags < 0) return false;
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+#endif
 }
 
 std::string addr_to_ip(const struct sockaddr_in& a) {
@@ -68,7 +76,6 @@ std::string addr_to_ip(const struct sockaddr_in& a) {
         return {};
     return buf;
 }
-#endif
 
 } // namespace
 
@@ -231,10 +238,6 @@ PortHopServer::~PortHopServer() {
 }
 
 bool PortHopServer::bind_all() {
-#ifdef _WIN32
-    NCP_LOG_ERROR("PortHopServer: Windows not supported in this module");
-    return false;
-#else
     if (bound_) return true;
 
     uint16_t range = schedule_.port_range();
@@ -243,10 +246,57 @@ bool PortHopServer::bind_all() {
         range = kMaxRange;
     }
 
+#ifdef _WIN32
+    if (!winsock_init()) {
+        NCP_LOG_ERROR("PortHopServer: WSAStartup failed");
+        return false;
+    }
+#endif
+
     for (uint16_t i = 0; i < range; ++i) {
         uint16_t port = static_cast<uint16_t>(schedule_.base_port() + i);
 
-        int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+#ifdef _WIN32
+        socket_t fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+        if (fd == kInvalidSocket) {
+            close();
+            return false;
+        }
+
+        int one = 1;
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
+                   reinterpret_cast<const char*>(&one), sizeof(one));
+        // NOTE: Windows has no SO_REUSEPORT. On Windows SO_REUSEADDR for
+        // UDP already permits a second bind to the same port, covering the
+        // "allow rebinding" half of the POSIX semantics; the load-balancing
+        // half of SO_REUSEPORT has no Winsock equivalent. Here each socket
+        // binds a *distinct* port of the hop range, so nothing is actually
+        // shared and the option only matters when several NCP instances
+        // (or a previous run in TIME_WAIT-like hold) overlap.
+
+        struct sockaddr_in addr;
+        std::memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        addr.sin_port = htons(port);
+
+        if (::bind(fd, reinterpret_cast<struct sockaddr*>(&addr),
+                   sizeof(addr)) == SOCKET_ERROR) {
+            NCP_LOG_ERROR("PortHopServer: bind failed on port " +
+                          std::to_string(port) + ": WSA error " +
+                          std::to_string(::WSAGetLastError()));
+            ::closesocket(fd);
+            close();
+            return false;
+        }
+
+        if (!set_nonblocking(fd)) {
+            ::closesocket(fd);
+            close();
+            return false;
+        }
+#else
+        socket_t fd = ::socket(AF_INET, SOCK_DGRAM, 0);
         if (fd < 0) {
             close();
             return false;
@@ -276,6 +326,7 @@ bool PortHopServer::bind_all() {
             close();
             return false;
         }
+#endif
 
         sockets_.push_back(fd);
         bound_ports_.push_back(port);
@@ -283,14 +334,16 @@ bool PortHopServer::bind_all() {
 
     bound_ = true;
     return true;
-#endif
 }
 
 void PortHopServer::close() {
-#ifndef _WIN32
-    for (int fd : sockets_)
+    for (socket_t fd : sockets_) {
+#ifdef _WIN32
+        ::closesocket(fd);
+#else
         ::close(fd);
 #endif
+    }
     sockets_.clear();
     bound_ports_.clear();
     bound_ = false;
@@ -317,40 +370,56 @@ bool PortHopServer::has_session(uint64_t session_id) const {
 
 std::vector<PortHopReceived> PortHopServer::poll(int timeout_ms) {
     std::vector<PortHopReceived> out;
-#ifndef _WIN32
     if (!bound_ || sockets_.empty())
         return out;
 
     fd_set rfds;
     FD_ZERO(&rfds);
-    int max_fd = -1;
-    for (int fd : sockets_) {
-        FD_SET(fd, &rfds);
-        if (fd > max_fd) max_fd = fd;
-    }
 
     struct timeval tv;
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000;
 
-    int ready = ::select(max_fd + 1, &rfds, nullptr, nullptr,
-                         timeout_ms >= 0 ? &tv : nullptr);
+    int ready;
+#ifdef _WIN32
+    // Winsock select() takes SOCKET handles and ignores the nfds argument.
+    for (socket_t fd : sockets_)
+        FD_SET(fd, &rfds);
+    ready = ::select(0, &rfds, nullptr, nullptr,
+                     timeout_ms >= 0 ? &tv : nullptr);
+#else
+    int max_fd = -1;
+    for (socket_t fd : sockets_) {
+        FD_SET(fd, &rfds);
+        if (fd > max_fd) max_fd = fd;
+    }
+    ready = ::select(max_fd + 1, &rfds, nullptr, nullptr,
+                     timeout_ms >= 0 ? &tv : nullptr);
+#endif
     if (ready <= 0)
         return out;
 
     uint8_t buf[kMaxDatagram];
     for (size_t i = 0; i < sockets_.size(); ++i) {
-        int fd = sockets_[i];
+        socket_t fd = sockets_[i];
         if (!FD_ISSET(fd, &rfds))
             continue;
 
         // Drain this socket (it is non-blocking).
         for (;;) {
             struct sockaddr_in from;
+#ifdef _WIN32
+            int from_len = sizeof(from);
+            const int n = ::recvfrom(fd, reinterpret_cast<char*>(buf),
+                                     static_cast<int>(sizeof(buf)), 0,
+                                     reinterpret_cast<struct sockaddr*>(&from),
+                                     &from_len);
+#else
             socklen_t from_len = sizeof(from);
             ssize_t n = ::recvfrom(fd, buf, sizeof(buf), 0,
                                    reinterpret_cast<struct sockaddr*>(&from),
                                    &from_len);
+#endif
             if (n <= 0)
                 break;
 
@@ -391,9 +460,6 @@ std::vector<PortHopReceived> PortHopServer::poll(int timeout_ms) {
             out.push_back(std::move(rec));
         }
     }
-#else
-    (void)timeout_ms;
-#endif
     return out;
 }
 
@@ -401,10 +467,6 @@ bool PortHopServer::send_to_session(uint64_t session_id,
                                     const uint8_t* payload,
                                     size_t payload_len,
                                     uint8_t flags) {
-#ifdef _WIN32
-    (void)session_id; (void)payload; (void)payload_len; (void)flags;
-    return false;
-#else
     if (!bound_ || sockets_.empty())
         return false;
 
@@ -419,6 +481,14 @@ bool PortHopServer::send_to_session(uint64_t session_id,
         std::memcpy(&peer, it->second.peer_addr.data(), sizeof(peer));
     }
 
+#ifdef _WIN32
+    const int n = ::sendto(sockets_.front(),
+                           reinterpret_cast<const char*>(wire.data()),
+                           static_cast<int>(wire.size()), 0,
+                           reinterpret_cast<struct sockaddr*>(&peer),
+                           sizeof(peer));
+    return n == static_cast<int>(wire.size());
+#else
     ssize_t n = ::sendto(sockets_.front(), wire.data(), wire.size(), 0,
                          reinterpret_cast<struct sockaddr*>(&peer),
                          sizeof(peer));
@@ -427,10 +497,6 @@ bool PortHopServer::send_to_session(uint64_t session_id,
 }
 
 bool PortHopServer::send_ack(uint64_t session_id, uint32_t acked_seq) {
-#ifdef _WIN32
-    (void)session_id; (void)acked_seq;
-    return false;
-#else
     if (!bound_ || sockets_.empty())
         return false;
 
@@ -451,6 +517,14 @@ bool PortHopServer::send_ack(uint64_t session_id, uint32_t acked_seq) {
         std::memcpy(&peer, it->second.peer_addr.data(), sizeof(peer));
     }
 
+#ifdef _WIN32
+    const int n = ::sendto(sockets_.front(),
+                           reinterpret_cast<const char*>(wire.data()),
+                           static_cast<int>(wire.size()), 0,
+                           reinterpret_cast<struct sockaddr*>(&peer),
+                           sizeof(peer));
+    return n == static_cast<int>(wire.size());
+#else
     ssize_t n = ::sendto(sockets_.front(), wire.data(), wire.size(), 0,
                          reinterpret_cast<struct sockaddr*>(&peer),
                          sizeof(peer));
@@ -497,11 +571,38 @@ PortHopClient::~PortHopClient() {
 }
 
 bool PortHopClient::open() {
-#ifdef _WIN32
-    return false;
-#else
-    if (socket_ >= 0) return true;
+    if (socket_ != kInvalidSocket) return true;
 
+#ifdef _WIN32
+    if (!winsock_init()) return false;
+
+    socket_t fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd == kInvalidSocket) return false;
+    if (!set_nonblocking(fd)) {
+        ::closesocket(fd);
+        return false;
+    }
+
+    // Bind to an ephemeral port so replies have a stable source.
+    struct sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(0);
+    if (::bind(fd, reinterpret_cast<struct sockaddr*>(&addr),
+               sizeof(addr)) == SOCKET_ERROR) {
+        ::closesocket(fd);
+        return false;
+    }
+
+    int len = sizeof(addr);
+    if (::getsockname(fd, reinterpret_cast<struct sockaddr*>(&addr),
+                      &len) == 0)
+        local_port_ = ntohs(addr.sin_port);
+
+    socket_ = fd;
+    return true;
+#else
     int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
     if (fd < 0) return false;
     if (!set_nonblocking(fd)) {
@@ -532,24 +633,23 @@ bool PortHopClient::open() {
 }
 
 void PortHopClient::close() {
-#ifndef _WIN32
-    if (socket_ >= 0)
+    if (socket_ != kInvalidSocket) {
+#ifdef _WIN32
+        ::closesocket(socket_);
+#else
         ::close(socket_);
 #endif
-    socket_ = -1;
+    }
+    socket_ = kInvalidSocket;
 }
 
 bool PortHopClient::is_open() const {
-    return socket_ >= 0;
+    return socket_ != kInvalidSocket;
 }
 
 bool PortHopClient::send(const uint8_t* payload, size_t payload_len,
                          uint8_t flags) {
-#ifdef _WIN32
-    (void)payload; (void)payload_len; (void)flags;
-    return false;
-#else
-    if (socket_ < 0) return false;
+    if (socket_ == kInvalidSocket) return false;
 
     std::vector<uint8_t> wire = session_.encode(payload, payload_len, flags);
     uint16_t port = schedule_.port_for_epoch(session_.current_epoch());
@@ -561,6 +661,13 @@ bool PortHopClient::send(const uint8_t* payload, size_t payload_len,
     if (::inet_pton(AF_INET, server_ip_.c_str(), &to.sin_addr) != 1)
         return false;
 
+#ifdef _WIN32
+    const int n = ::sendto(socket_, reinterpret_cast<const char*>(wire.data()),
+                           static_cast<int>(wire.size()), 0,
+                           reinterpret_cast<struct sockaddr*>(&to),
+                           sizeof(to));
+    return n == static_cast<int>(wire.size());
+#else
     ssize_t n = ::sendto(socket_, wire.data(), wire.size(), 0,
                          reinterpret_cast<struct sockaddr*>(&to), sizeof(to));
     return n == static_cast<ssize_t>(wire.size());
@@ -573,8 +680,7 @@ bool PortHopClient::send(const std::vector<uint8_t>& payload, uint8_t flags) {
 
 std::vector<PortHopReceived> PortHopClient::poll(int timeout_ms) {
     std::vector<PortHopReceived> out;
-#ifndef _WIN32
-    if (socket_ < 0) return out;
+    if (socket_ == kInvalidSocket) return out;
 
     fd_set rfds;
     FD_ZERO(&rfds);
@@ -584,17 +690,30 @@ std::vector<PortHopReceived> PortHopClient::poll(int timeout_ms) {
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000;
 
+#ifdef _WIN32
+    // Winsock select() ignores the nfds argument.
+    int ready = ::select(0, &rfds, nullptr, nullptr, &tv);
+#else
     int ready = ::select(socket_ + 1, &rfds, nullptr, nullptr, &tv);
+#endif
     if (ready <= 0)
         return out;
 
     uint8_t buf[kMaxDatagram];
     for (;;) {
         struct sockaddr_in from;
+#ifdef _WIN32
+        int from_len = sizeof(from);
+        const int n = ::recvfrom(socket_, reinterpret_cast<char*>(buf),
+                                 static_cast<int>(sizeof(buf)), 0,
+                                 reinterpret_cast<struct sockaddr*>(&from),
+                                 &from_len);
+#else
         socklen_t from_len = sizeof(from);
         ssize_t n = ::recvfrom(socket_, buf, sizeof(buf), 0,
                                reinterpret_cast<struct sockaddr*>(&from),
                                &from_len);
+#endif
         if (n <= 0)
             break;
 
@@ -609,9 +728,6 @@ std::vector<PortHopReceived> PortHopClient::poll(int timeout_ms) {
         rec.local_port = local_port_;
         out.push_back(std::move(rec));
     }
-#else
-    (void)timeout_ms;
-#endif
     return out;
 }
 

--- a/src/core/src/ncp_reality.cpp
+++ b/src/core/src/ncp_reality.cpp
@@ -8,7 +8,10 @@
 
 #include <sodium.h>
 
-#ifndef _WIN32
+#ifdef _WIN32
+// ncp_winsock_init.hpp (via ncp_reality.hpp) already provides
+// <winsock2.h>/<ws2tcpip.h>, ncp::socket_t and ncp::winsock_init().
+#else
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -103,12 +106,23 @@ bool split_sni(const std::string& sni, std::string& token,
     return true;
 }
 
-// Write all bytes, retrying on EINTR; MSG_NOSIGNAL against SIGPIPE.
-// Windows: the TCP splice path is not supported yet, stubbed out.
-bool write_all([[maybe_unused]] int fd, [[maybe_unused]] const uint8_t* data,
-               [[maybe_unused]] size_t len) noexcept {
+// Write all bytes, retrying on EINTR/WSAEINTR; MSG_NOSIGNAL against SIGPIPE
+// on POSIX (Winsock never raises SIGPIPE, so the flag is 0 there).
+bool write_all(socket_t fd, const uint8_t* data, size_t len) noexcept {
 #ifdef _WIN32
-    return false;
+    size_t off = 0;
+    while (off < len) {
+        // Winsock send() takes an int length; our buffers are <= 16 KiB.
+        const int n = ::send(fd, reinterpret_cast<const char*>(data + off),
+                             static_cast<int>(len - off), 0);
+        if (n == SOCKET_ERROR) {
+            if (::WSAGetLastError() == WSAEINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;
+        off += static_cast<size_t>(n);
+    }
+    return true;
 #else
     size_t off = 0;
     while (off < len) {
@@ -124,10 +138,28 @@ bool write_all([[maybe_unused]] int fd, [[maybe_unused]] const uint8_t* data,
 #endif
 }
 
-int connect_to([[maybe_unused]] const std::string& host,
-               [[maybe_unused]] uint16_t port) noexcept {
+socket_t connect_to(const std::string& host, uint16_t port) noexcept {
 #ifdef _WIN32
-    return -1;  // TCP fallback dial is not supported on Windows yet
+    if (!winsock_init()) return kInvalidSocket;
+    struct addrinfo hints {};
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    const std::string port_str = std::to_string(port);
+    struct addrinfo* res = nullptr;
+    if (::getaddrinfo(host.c_str(), port_str.c_str(), &hints, &res) != 0) {
+        return kInvalidSocket;
+    }
+    socket_t fd = kInvalidSocket;
+    for (struct addrinfo* ai = res; ai != nullptr; ai = ai->ai_next) {
+        fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (fd == kInvalidSocket) continue;
+        if (::connect(fd, ai->ai_addr, static_cast<int>(ai->ai_addrlen)) == 0)
+            break;
+        ::closesocket(fd);
+        fd = kInvalidSocket;
+    }
+    ::freeaddrinfo(res);
+    return fd;
 #else
     struct addrinfo hints {};
     hints.ai_family   = AF_UNSPEC;
@@ -333,10 +365,56 @@ RealityServer::Decision RealityServer::classify(const uint8_t* clienthello,
     return Decision::FALLBACK;
 }
 
-void RealityServer::splice([[maybe_unused]] int fd_a,
-                           [[maybe_unused]] int fd_b) noexcept {
+void RealityServer::splice(socket_t fd_a, socket_t fd_b) noexcept {
 #ifdef _WIN32
-    return;  // bidirectional splice is not supported on Windows yet
+    if (fd_a == kInvalidSocket || fd_b == kInvalidSocket) return;
+    bool read_a = true;  // still reading from fd_a
+    bool read_b = true;  // still reading from fd_b
+    std::array<uint8_t, 16384> buf{};
+
+    while (read_a || read_b) {
+        // WSAPoll is available since Vista (the project targets
+        // _WIN32_WINNT=0x0A00); POLLIN/POLLHUP/POLLERR flags match POSIX.
+        WSAPOLLFD pfds[2];
+        pfds[0].fd = read_a ? fd_a : kInvalidSocket;
+        pfds[0].events = POLLIN;
+        pfds[0].revents = 0;
+        pfds[1].fd = read_b ? fd_b : kInvalidSocket;
+        pfds[1].events = POLLIN;
+        pfds[1].revents = 0;
+
+        const int rc = ::WSAPoll(pfds, 2, -1);
+        if (rc == SOCKET_ERROR) {
+            if (::WSAGetLastError() == WSAEINTR) continue;
+            break;
+        }
+
+        for (int side = 0; side < 2; ++side) {
+            const bool is_a = (side == 0);
+            bool& reading = is_a ? read_a : read_b;
+            if (!reading) continue;
+            const short rev = pfds[side].revents;
+            if ((rev & (POLLIN | POLLHUP | POLLERR)) == 0) continue;
+
+            const socket_t src = is_a ? fd_a : fd_b;
+            const socket_t dst = is_a ? fd_b : fd_a;
+            const int n = ::recv(src, reinterpret_cast<char*>(buf.data()),
+                                 static_cast<int>(buf.size()), 0);
+            if (n > 0) {
+                if (!write_all(dst, buf.data(), static_cast<size_t>(n))) {
+                    // Peer write side is dead: stop forwarding both ways.
+                    ::shutdown(dst, SD_SEND);
+                    reading = false;
+                    (is_a ? read_b : read_a) = false;
+                }
+            } else {
+                // EOF or error: half-close the opposite direction and
+                // keep forwarding the remaining direction.
+                ::shutdown(dst, SD_SEND);
+                reading = false;
+            }
+        }
+    }
 #else
     if (fd_a < 0 || fd_b < 0) return;
     bool read_a = true;  // still reading from fd_a
@@ -386,10 +464,50 @@ void RealityServer::splice([[maybe_unused]] int fd_a,
 #endif
 }
 
-bool RealityServer::handle_client([[maybe_unused]] int client_fd,
-                                  [[maybe_unused]] uint64_t now) const noexcept {
+bool RealityServer::handle_client(socket_t client_fd,
+                                  uint64_t now) const noexcept {
 #ifdef _WIN32
-    return false;  // fallback relay is not supported on Windows yet
+    if (client_fd == kInvalidSocket) return false;
+    if (!winsock_init()) return false;
+
+    // Read the ClientHello (single record, capped at 16 KiB).
+    std::array<uint8_t, 16384> hello{};
+    size_t have = 0;
+    while (have < hello.size()) {
+        const int n = ::recv(client_fd,
+                             reinterpret_cast<char*>(hello.data()) + have,
+                             static_cast<int>(hello.size() - have), 0);
+        if (n <= 0) return false;
+        have += static_cast<size_t>(n);
+        if (have >= 5) {
+            const size_t rec_len =
+                (static_cast<size_t>(hello[3]) << 8) | hello[4];
+            if (5 + rec_len > hello.size()) return false;  // oversize record
+            if (have >= 5 + rec_len) break;
+        }
+    }
+
+    const Decision d = classify(hello.data(), have, now);
+    if (d == Decision::NOT_TLS) return false;
+
+    const std::string& host = (d == Decision::AUTHORIZED)
+                                  ? cfg_.internal_host
+                                  : cfg_.fallback_host;
+    const uint16_t port = (d == Decision::AUTHORIZED)
+                              ? cfg_.internal_port
+                              : cfg_.fallback_port;
+
+    const socket_t upstream = connect_to(host, port);
+    if (upstream == kInvalidSocket) return false;
+
+    // Replay the consumed ClientHello bytes to the chosen upstream.
+    if (!write_all(upstream, hello.data(), have)) {
+        ::closesocket(upstream);
+        return false;
+    }
+    splice(client_fd, upstream);
+    ::closesocket(upstream);
+    return true;
 #else
     if (client_fd < 0) return false;
 

--- a/src/core/src/ncp_spa.cpp
+++ b/src/core/src/ncp_spa.cpp
@@ -456,9 +456,34 @@ bool SpaClient::send_packet(const std::string& host, uint16_t udp_port,
     if (pkt.size() != SPA_PACKET_SIZE) return false;
 
 #ifdef _WIN32
-    NCP_LOG_ERROR("[SPA] knock is not supported on Windows yet");
-    (void)host; (void)udp_port;
-    return false;
+    if (!winsock_init()) {
+        NCP_LOG_ERROR("[SPA] WSAStartup failed");
+        return false;
+    }
+    struct addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    struct addrinfo* res = nullptr;
+    const std::string port_str = std::to_string(udp_port);
+    if (::getaddrinfo(host.c_str(), port_str.c_str(), &hints, &res) != 0 || !res) {
+        NCP_LOG_ERROR(std::string("[SPA] cannot resolve ") + host);
+        return false;
+    }
+    bool sent = false;
+    for (struct addrinfo* ai = res; ai && !sent; ai = ai->ai_next) {
+        socket_t s = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (s == kInvalidSocket) continue;
+        const int n = ::sendto(s, reinterpret_cast<const char*>(pkt.data()),
+                               static_cast<int>(pkt.size()), 0,
+                               ai->ai_addr, static_cast<int>(ai->ai_addrlen));
+        ::closesocket(s);
+        sent = (n == static_cast<int>(pkt.size()));
+    }
+    ::freeaddrinfo(res);
+    if (!sent) {
+        NCP_LOG_ERROR(std::string("[SPA] knock send failed to ") + host);
+    }
+    return sent;
 #else
     struct addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
@@ -499,8 +524,55 @@ SpaDaemon::~SpaDaemon() {
 
 bool SpaDaemon::start() {
 #ifdef _WIN32
-    NCP_LOG_ERROR("[SPA] SpaDaemon is not supported on Windows yet");
-    return false;
+    if (running_.load()) return true;
+    if (!winsock_init()) {
+        NCP_LOG_ERROR("[SPA] WSAStartup failed");
+        return false;
+    }
+
+    sock_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock_ == kInvalidSocket) {
+        NCP_LOG_ERROR(std::string("[SPA] socket() failed, WSA error ") +
+                      std::to_string(::WSAGetLastError()));
+        return false;
+    }
+
+    int one = 1;
+    ::setsockopt(sock_, SOL_SOCKET, SO_REUSEADDR,
+                 reinterpret_cast<const char*>(&one), sizeof(one));
+
+    // SO_RCVTIMEO on Windows takes a DWORD timeout in milliseconds
+    // (1 s loop so stop() is responsive); an expired recvfrom fails with
+    // WSAETIMEDOUT, matching the POSIX EAGAIN/EWOULDBLOCK tick below.
+    DWORD tv_ms = 1000;
+    ::setsockopt(sock_, SOL_SOCKET, SO_RCVTIMEO,
+                 reinterpret_cast<const char*>(&tv_ms), sizeof(tv_ms));
+
+    struct sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port_);
+    if (::inet_pton(AF_INET, bind_addr_.c_str(), &addr.sin_addr) != 1) {
+        NCP_LOG_ERROR(std::string("[SPA] invalid bind address: ") + bind_addr_);
+        ::closesocket(sock_);
+        sock_ = kInvalidSocket;
+        return false;
+    }
+    if (::bind(sock_, reinterpret_cast<struct sockaddr*>(&addr),
+               sizeof(addr)) == SOCKET_ERROR) {
+        NCP_LOG_ERROR(std::string("[SPA] bind ") + bind_addr_ + ":" +
+                      std::to_string(port_) + " failed, WSA error " +
+                      std::to_string(::WSAGetLastError()));
+        ::closesocket(sock_);
+        sock_ = kInvalidSocket;
+        return false;
+    }
+
+    stop_flag_.store(false);
+    running_.store(true);
+    thread_ = std::thread(&SpaDaemon::loop, this);
+    NCP_LOG_INFO(std::string("[SPA] daemon listening on UDP ") + bind_addr_ +
+                 ":" + std::to_string(port_));
+    return true;
 #else
     if (running_.load()) return true;
 
@@ -547,20 +619,36 @@ bool SpaDaemon::start() {
 void SpaDaemon::stop() {
     stop_flag_.store(true);
     if (thread_.joinable()) thread_.join();
-#ifndef _WIN32
-    if (sock_ >= 0) {
+    if (sock_ != kInvalidSocket) {
+#ifdef _WIN32
+        ::closesocket(sock_);
+#else
         ::close(sock_);
-        sock_ = -1;
-    }
 #endif
+        sock_ = kInvalidSocket;
+    }
     running_.store(false);
 }
 
 void SpaDaemon::loop() {
-#ifndef _WIN32
     std::vector<uint8_t> buf(SPA_PACKET_SIZE + 64);
     while (!stop_flag_.load()) {
         struct sockaddr_in src{};
+#ifdef _WIN32
+        int src_len = sizeof(src);
+        const int n = ::recvfrom(sock_, reinterpret_cast<char*>(buf.data()),
+                                 static_cast<int>(buf.size()), 0,
+                                 reinterpret_cast<struct sockaddr*>(&src),
+                                 &src_len);
+        if (n == SOCKET_ERROR) {
+            const int err = ::WSAGetLastError();
+            if (err == WSAETIMEDOUT || err == WSAEWOULDBLOCK) continue;  // 1 s tick
+            if (stop_flag_.load()) break;
+            NCP_LOG_WARN(std::string("[SPA] recvfrom error, WSA code ") +
+                         std::to_string(err));
+            continue;
+        }
+#else
         socklen_t src_len = sizeof(src);
         const ssize_t n = ::recvfrom(sock_, buf.data(), buf.size(), 0,
                                      reinterpret_cast<struct sockaddr*>(&src), &src_len);
@@ -570,12 +658,12 @@ void SpaDaemon::loop() {
             NCP_LOG_WARN(std::string("[SPA] recvfrom error: ") + std::strerror(errno));
             continue;
         }
+#endif
         char ip_str[INET_ADDRSTRLEN] = {0};
         ::inet_ntop(AF_INET, &src.sin_addr, ip_str, sizeof(ip_str));
         server_.process_packet(buf.data(), static_cast<size_t>(n), ip_str);
         // Never send replies — the port must stay silent.
     }
-#endif
 }
 
 } // namespace ncp


### PR DESCRIPTION
## Состав (3 коммита)

### 1. `feat(core)`: полноценные Winsock2-реализации вместо Windows-стабов
Заменены ВСЕ заглушки `_WIN32` в enterprise-модулях:
- **ncp_reality.cpp**: `write_all`/`connect_to`/`RealityServer::splice`/`RealityServer::handle_client` — Winsock2 (WSAPoll, shutdown(SD_SEND), half-close семантика сохранена)
- **ncp_fog.cpp**: `start` (ioctlsocket FIONBIO вместо fcntl), `stop`, `send_frame_to`, `poll` (Winsock select + WSAEWOULDBLOCK-дренаж)
- **ncp_spa.cpp**: knock-клиент (getaddrinfo+sendto) и SpaDaemon (recvfrom-цикл, SO_RCVTIMEO=DWORD мс, WSAETIMEDOUT-тик)
- **ncp_porthop.cpp**: PortHopServer/PortHopClient полностью (bind диапазона портов, select, session frames)
- **src/cli/main.cpp**: `reality serve` — настоящий listen/accept-цикл на Windows; `fog node` без ограничений
- Новый header-only `ncp_winsock_init.hpp`: `winsock_init()` через `std::call_once` + тип `socket_t` (SOCKET не обрезается до int)

`ncp_xdp` остаётся Linux-only осознанно: eBPF не существует на Windows — это платформенное ограничение, а не заглушка.

### 2. `ci(release)`: починка трёх упавших джобов release.yml
- **linux**: apt-get update с retry-циклом (падал на зависании archive.ubuntu.com); conan убран, зависимости из дистрибутива
- **macOS**: conan убран → brew libsodium + libwebsockets (рецепт из зелёного macos.yml); чинит ошибку `openssl::openssl` в conan-овском libwebsockets-config.cmake
- **Windows**: vcpkg (libsodium/libwebsockets/openssl:x64-windows) + msvc-dev-cmd + vcpkg toolchain; чинит FATAL_ERROR «libsodium is REQUIRED»; упаковка теперь включает Qt- и vcpkg-DLL (windeployqt) — ncp.exe реально запускается у пользователя

### 3. `ci(npm)`: авто-триггер npm-publish отключён до добавления секрета NPM_TOKEN
Первая публикация `dynam-ncp` — вручную; в файле оставлена инструкция по возврату триггера.

## Верификация
- Linux: syntax-only всех модулей + полная пересборка, **53/53 тестов Reality/Fog/Spa/PortHop PASSED** (включая splice на socketpair и SpaDaemon end-to-end)
- MinGW-кросс-проверка _WIN32-веток: все файлы OK с боевыми define'ами проекта
- Под wine: два FogNode обменялись UDP-датаграммой по loopback через новые Winsock-пути — «delivered 3 bytes: ABC»

Разблокирует GitHub Release v1.5.0 (все 3 платформы) и последующую публикацию в npm.